### PR TITLE
Print residue with insertion code

### DIFF
--- a/include/BALL/KERNEL/residue.h
+++ b/include/BALL/KERNEL/residue.h
@@ -79,10 +79,14 @@ namespace BALL
 			NO_VARIANT_EXTENSIONS,
 			/// Add the residue variant extensions (e.g. '-C' for C-terminal residues)
 			ADD_VARIANT_EXTENSIONS,
-			// Add the residue ID separated by a colon
-      ADD_RESIDUE_ID,
-      // Add the residue ID and the residue extension
-      ADD_VARIANT_EXTENSIONS_AND_ID
+			/// Add the residue ID, expected to be numeric, directly following the residue name
+			ADD_RESIDUE_ID,
+			/// Add the residue ID right after the residue extension (if available) or the name (otherwise).
+			ADD_VARIANT_EXTENSIONS_AND_ID,
+			/// After the residue ID show the insertion code
+			ADD_RESIDUE_ID_AND_INSERTION_CODE,
+			/// All: show the residue name with its optional extension, then the ID with its optional insertion code and the residue extension
+			ADD_VARIANT_EXTENSIONS_AND_ID_AND_INSERTION_CODE
 		};
 
 		//@}

--- a/source/KERNEL/residue.C
+++ b/source/KERNEL/residue.C
@@ -555,6 +555,11 @@ namespace BALL
 		{
 			full_name += String(getID());
 		}
+		if (BALL_RESIDUE_DEFAULT_INSERTION_CODE != insertion_code_ &&
+		    (type == ADD_RESIDUE_ID_AND_INSERTION_CODE || type == ADD_VARIANT_EXTENSIONS_AND_ID_AND_INSERTION_CODE))
+		{
+			full_name += String(getInsertionCode());
+		}
 
 		return full_name;
 	}

--- a/source/PYTHON/EXTENSIONS/BALL/residue.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/residue.sip
@@ -24,10 +24,15 @@ class Residue
    	PROPERTY__CYCLIC,
    	NUMBER_OF_PROPERTIES
   };
+  // following the definition of FullNameType in BALL/KERNEL/residue.h
   enum FullNameType
   {
    	NO_VARIANT_EXTENSIONS,
-   	ADD_VARIANT_EXTENSIONS
+   	ADD_VARIANT_EXTENSIONS,
+   	ADD_RESIDUE_ID,
+	ADD_VARIANT_EXTENSIONS_AND_ID,
+	ADD_RESIDUE_ID_AND_INSERTION_CODE,
+	ADD_VARIANT_EXTENSIONS_AND_ID_AND_INSERTION_CODE
   };
   Residue();
   Residue(const Residue&, bool deep = true);
@@ -86,7 +91,9 @@ class Residue
 
   SIP_PYOBJECT __str__();
 %MethodCode
-	sipRes = PyString_FromString(String(String("Residue ") + sipCpp->getName() + sipCpp->getID()
-    			    + " { " + String(sipCpp->countAtoms()) + " atoms }").c_str());
+	sipRes = PyString_FromString(String(
+		                            String("Residue ")
+		                          + sipCpp->getFullName(ADD_VARIANT_EXTENSIONS_AND_ID_AND_INSERTION_CODE)
+		                          + " { " + String(sipCpp->countAtoms()) + " atoms }").c_str());
 %End
 };

--- a/source/PYTHON/EXTENSIONS/BALL/residue.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/residue.sip
@@ -46,7 +46,7 @@ class Residue
   // Residue& operator = (const Residue& residue);
   void get(Residue&, bool deep = true) const;
   void swap(Residue&);
-  String getFullName(FullNameType type = ADD_VARIANT_EXTENSIONS) const;
+  String getFullName(FullNameType type = ADD_VARIANT_EXTENSIONS_AND_ID_AND_INSERTION_CODE) const;
   bool hasTorsionPhi() const;
   Angle getTorsionPhi() const;
   bool hasTorsionPsi() const;
@@ -93,7 +93,7 @@ class Residue
 %MethodCode
 	sipRes = PyString_FromString(String(
 		                            String("Residue ")
-		                          + sipCpp->getFullName(ADD_VARIANT_EXTENSIONS_AND_ID_AND_INSERTION_CODE)
+		                          + sipCpp->getFullName()
 		                          + " { " + String(sipCpp->countAtoms()) + " atoms }").c_str());
 %End
 };


### PR DESCRIPTION
This was a bit of a technical exercise while continuing the thoughts expressed in issue https://github.com/BALL-Project/ball/issues/544 on the visibility of the insertion code. The getFullName method is extended respectively and the python_toString routine falls back to it. The patch required to also update and extend the FullnameType enum for Python.
