### PR TITLE
Fix : adding Visual Studio compatibility

### DIFF
--- a/source/STRUCTURE/connectedComponentsProcessor.C
+++ b/source/STRUCTURE/connectedComponentsProcessor.C
@@ -32,7 +32,7 @@ namespace BALL
 		// about 30-50% of the whole computation time in this method!!!
 		const int num_atoms = ac.countAtoms();
 		// mapping: atom to int, and int to atom:
-		Atom* i_to_atm[num_atoms];
+		Atom** i_to_atm = (Atom **) alloca (num_atoms);
 		std::map< Atom*, int> atm_to_i; // std::map was most efficient, compared with hashmaps
 		
 		// create empty disjoint set:


### PR DESCRIPTION
Visual studio compiler does not support variable length arrays. So the previous code did not compile on Windows. the use of alloca resolve this problem.