### PR TITLE
Python: Added Omega torsion angles

### DIFF
--- a/include/BALL/STRUCTURE/residueRotamerSet.h
+++ b/include/BALL/STRUCTURE/residueRotamerSet.h
@@ -205,6 +205,15 @@ namespace BALL
 
 		///
 		void setTorsionPsi(const Angle& psi);
+
+		///
+		bool hasTorsionOmega() const;
+
+		///
+		Angle getTorsionOmega() const;
+
+		///
+		void setTorsionOmega(const Angle& psi);
 		//@}
 
 		/**	@name	Rotamer Assignment
@@ -297,11 +306,17 @@ namespace BALL
 		/// true if this residue rotamer set is backbone dependent
 		bool has_torsion_psi_;
 
+		/// true if this residue rotamer set is backbone dependent
+		bool has_torsion_omega_;
+
 		/// The torsion phi
 		Angle phi_;
 
 		/// The torsion psi
 		Angle psi_;
+
+		/// The torsion omega
+		Angle omega_;
 	};
 
 } // namespace BALL

--- a/source/KERNEL/residue.C
+++ b/source/KERNEL/residue.C
@@ -243,8 +243,8 @@ namespace BALL
 		{
 			return false;
 		}
-		// the torsion angle phi is not defined for
-		// the N-terminus
+		// the torsion angle omega is not defined for
+		// the C-terminus
 		return  !isCTerminal() && hasProperty(PROPERTY__AMINO_ACID);
 	}
 

--- a/source/PYTHON/EXTENSIONS/BALL/residue.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/residue.sip
@@ -46,6 +46,8 @@ class Residue
   Angle getTorsionPhi() const;
   bool hasTorsionPsi() const;
   Angle getTorsionPsi() const;  
+  bool hasTorsionOmega() const;
+  Angle getTorsionOmega() const;  
 
   Protein* getProtein();
   // const Protein* getProtein() const;

--- a/source/PYTHON/EXTENSIONS/BALL/residueRotamerSet.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/residueRotamerSet.sip
@@ -48,6 +48,9 @@ class ResidueRotamerSet
 		bool hasTorsionPsi() const;
 		Angle getTorsionPsi() const;
 		void setTorsionPsi(const Angle& psi);
+		bool hasTorsionOmega() const;
+		Angle getTorsionOmega() const;
+		void setTorsionOmega(const Angle& omega);
 		bool setTemplateResidue(const Residue& residue, Size number_of_torsions);
 		bool setRotamer(Residue& residue, const Rotamer& rotamer);
 		Rotamer getRotamer(const Residue& residue) const;

--- a/source/STRUCTURE/residueRotamerSet.C
+++ b/source/STRUCTURE/residueRotamerSet.C
@@ -53,8 +53,10 @@ namespace BALL
 			number_of_torsions_(0),
 			has_torsion_phi_(false),
 			has_torsion_psi_(false),
+			has_torsion_omega_(false),
 			phi_(0),
-			psi_(0)
+			psi_(0),
+			omega_(0)
 	{
 	}
         
@@ -70,8 +72,10 @@ namespace BALL
 			number_of_torsions_(number_of_torsions),
 			has_torsion_phi_(false),
 			has_torsion_psi_(false),
+			has_torsion_omega_(false),
 			phi_(0),
-			psi_(0)
+			psi_(0),
+			omega_(0)
 
 	{
 		setTemplateResidue(residue, number_of_torsions);
@@ -261,8 +265,10 @@ namespace BALL
 			original_coordinates_(rhs.original_coordinates_),
 			has_torsion_phi_(rhs.has_torsion_phi_),
 			has_torsion_psi_(rhs.has_torsion_psi_),
+			has_torsion_omega_(rhs.has_torsion_omega_),
 			phi_(rhs.phi_),
-			psi_(rhs.psi_)
+			psi_(rhs.psi_),
+			omega_(rhs.omega_)
 	{
 	}
 
@@ -285,8 +291,10 @@ namespace BALL
 			original_coordinates_ = rhs.original_coordinates_;
 			has_torsion_phi_ = rhs.has_torsion_phi_;
 			has_torsion_psi_ = rhs.has_torsion_psi_;
+			has_torsion_omega_ = rhs.has_torsion_omega_;
 			phi_ = rhs.phi_;
 			psi_ = rhs.psi_;
+			omega_ = rhs.omega_;
 		}
 
 		return (*this);
@@ -809,6 +817,22 @@ namespace BALL
 	{
 		psi_ = angle;
 		has_torsion_psi_ = true;
+	}
+
+	bool ResidueRotamerSet::hasTorsionOmega() const
+	{
+		return has_torsion_omega_;
+	}
+
+	Angle ResidueRotamerSet::getTorsionOmega() const
+	{
+		return omega_;
+	}
+
+	void ResidueRotamerSet::setTorsionOmega(const Angle& angle)
+	{
+		omega_ = angle;
+		has_torsion_omega_ = true;
 	}
 
 	void ResidueRotamerSet::sort()


### PR DESCRIPTION
Dear all,

We are working with collagens over here (motivated by an autoimmune disease targetting them in the skin) and those are exceptionally rich in Glycines and (Hydroxy-)Prolines, so we thought we better have a look at the Omega dihedral angles rather than only Psi and Phi.

To keep it short: The BALL python interface did not know much about omega torsions but it does now. While grepping through your source tree I had found additional occurences of psi and phi, which stimulated adding omega there, too. You may have reasons to decide against those extra bits.

Best,

Steffen
