### PR TITLE
Vector3 unary - operator for Python API

### DIFF
--- a/source/PYTHON/EXTENSIONS/BALL/vector2.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/vector2.sip
@@ -62,7 +62,7 @@ class Vector2
 %End
 
 	// ???? const Vector2& operator + () const throw();
-	// ???? Vector2 operator - () const	throw();
+	Vector2 operator - () const	throw();
 	Vector2 operator + (const Vector2&) const throw();
 	Vector2 operator - (const Vector2&) const throw();
 	Vector2& operator += (const Vector2&) throw();

--- a/source/PYTHON/EXTENSIONS/BALL/vector3.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/vector3.sip
@@ -49,7 +49,7 @@ class Vector3
 
   // float operator [] (Index) const;
   // ???? const Vector3& operator + () const;
-  // ???? Vector3 operator - () const;
+  Vector3 operator - () const;
   Vector3& operator += (const Vector3&);
   Vector3& operator -= (const Vector3&);
  //???? Vector3& operator *= (float);

--- a/source/PYTHON/EXTENSIONS/BALL/vector4.sip
+++ b/source/PYTHON/EXTENSIONS/BALL/vector4.sip
@@ -41,7 +41,7 @@ class Vector4
 
   // float operator [] (Index) const;
   // ???? Vector4 operator + () const;
-  // ???? Vector4 operator - () const;
+  Vector4 operator - () const;
   Vector4& operator += (const Vector4&);
   Vector4& operator -= (const Vector4&);
   Vector4 operator * (float);


### PR DESCRIPTION
Fix for https://github.com/BALL-Project/ball/issues/556 . The respected bits just had to be commented out from the
.sip file:
<pre>
In [3]: print Vector3(1,1,1)
(1.000000 1.000000 1.000000)

In [4]: print -Vector3(1,1,1)
(-1.000000 -1.000000 -1.000000)
</pre>