### PR TITLE
Simplify many boolean expressions

### DIFF
--- a/source/APPLICATIONS/TOOLS/CombiLibGenerator.C
+++ b/source/APPLICATIONS/TOOLS/CombiLibGenerator.C
@@ -22,9 +22,7 @@ vector<String> scaffolds;
 
 bool isSection(String line)
 {
-	if (line[0] == '<' && line[line.size()-1] == '>')
-		return true;
-	return false;
+	return line[0] == '<' && line[line.size()-1] == '>';
 }
 
 bool findRGroupNames()

--- a/source/APPLICATIONS/TOOLS/ExtractClustersFromWardTree.C
+++ b/source/APPLICATIONS/TOOLS/ExtractClustersFromWardTree.C
@@ -90,7 +90,7 @@ int main (int argc, char **argv)
 	pc.options.set(PoseClustering::Option::CLUSTER_METHOD, PoseClustering::NEAREST_NEIGHBOR_CHAIN_WARD);
 
 	// import a binary file
-	bool binary = parpars.get("i_type") == "binary" ? true : false;
+	bool binary = parpars.get("i_type") == "binary";
 	pc.deserializeWardClusterTree(tree, binary);
 
 	int min_cluster_size = 0;

--- a/source/APPLICATIONS/TOOLS/LigCheck.C
+++ b/source/APPLICATIONS/TOOLS/LigCheck.C
@@ -185,14 +185,7 @@ bool checkMolecule(Molecule* mol, int molecule_no, map<String, pair<int, String>
 		Log.level(10)<<"   "<<"Error for molecule "<<molecule_no<<":"<<" atoms with nonsense partial charges detected!"<<endl;
 	}
 
-	if (!has_atoms || !has_hydrogens || !has_3D_coordinates || !one_molecule || !bond_length_ok || !elements_ok || !partial_charges_ok)
-	{
-		return false;
-	}
-	else
-	{
-		return true;
-	}
+	return has_atoms && has_hydrogens && has_3D_coordinates && one_molecule && bond_length_ok && elements_ok && partial_charges_ok;
 }
 
 

--- a/source/APPLICATIONS/TOOLS/Ligand3DGenerator.C
+++ b/source/APPLICATIONS/TOOLS/Ligand3DGenerator.C
@@ -132,14 +132,7 @@ bool advancedMoleculeCheck(Molecule* mol)
 		}
 	}
 	
-	if (all_x_zero || all_y_zero || all_z_zero)
-	{
-		return false;
-	}
-	else
-	{
-		return true;
-	}
+	return !(all_x_zero || all_y_zero || all_z_zero);
 }
 
 

--- a/source/APPLICATIONS/TOOLS/ProteinCheck.C
+++ b/source/APPLICATIONS/TOOLS/ProteinCheck.C
@@ -404,14 +404,7 @@ bool checkProtein(Protein* protein, bool allow_broken_chains)
 		Log.level(20)<<"passed"<<endl;
 	}
 
-	if (!has_atoms || !has_hydrogens || !has_3D_coordinates || !one_molecule || !bond_length_ok || !elements_ok || !temp_factor_ok)
-	{
-		return false;
-	}
-	else
-	{
-		return true;
-	}
+	return has_atoms && has_hydrogens && has_3D_coordinates && one_molecule && bond_length_ok && elements_ok && temp_factor_ok;
 }
 
 

--- a/source/APPLICATIONS/UTILITIES/clip_protein_around_ligand.C
+++ b/source/APPLICATIONS/UTILITIES/clip_protein_around_ligand.C
@@ -258,7 +258,7 @@ int main(int argc, char** argv)
 	// now load the molecules 
 	System protein;
 
-	if (use_hin_protein == true)
+	if (use_hin_protein)
 	{
 		HINFile protein_file(protein_file_name);
 		protein_file >> protein;
@@ -279,7 +279,7 @@ int main(int argc, char** argv)
 
 	System ligand;
 
-	if (use_hin_ligand == true)
+	if (use_hin_ligand)
 	{
 		HINFile ligand_hin_file;
 		ligand_hin_file.open(ligand_file_name);

--- a/source/APPLICATIONS/UTILITIES/reconstruct_fragment.C
+++ b/source/APPLICATIONS/UTILITIES/reconstruct_fragment.C
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
 	FragmentDB db("");
 	system.apply(db.normalize_names);
 
-	if (automatic == true)
+	if (automatic)
 	{
 		ReconstructFragmentProcessor proc(db);
 		system.apply(proc);

--- a/source/CONCEPT/composite.C
+++ b/source/CONCEPT/composite.C
@@ -54,7 +54,7 @@ namespace BALL
 			selection_stamp_(),
 			modification_stamp_()
 	{
-		if (deep == true)
+		if (deep)
 		{
 			composite.clone(*this);
 		}
@@ -74,7 +74,7 @@ namespace BALL
 
 	void Composite::set(const Composite& composite, bool deep)
 	{
-		if (deep == true)
+		if (deep)
 		{
 			// predicative cloning
 			composite.clone(*this);
@@ -575,7 +575,7 @@ namespace BALL
 	void Composite::prependChild(Composite& composite)
 	{
 		// avoid self-prepend and prepend of children
-		if (&composite == this || isDescendantOf(composite) == true)
+		if (&composite == this || isDescendantOf(composite))
 		{
 			return;
 		}
@@ -630,7 +630,7 @@ namespace BALL
 	void Composite::appendChild(Composite& composite)
 	{
 		// avoid self-appending and appending of parent nodes
-		if (&composite == this || isDescendantOf(composite) == true)
+		if (&composite == this || isDescendantOf(composite))
 		{
 			return;
 		}
@@ -692,7 +692,7 @@ namespace BALL
 		}
 
 		// if first is already a child of parent, return immediately
-		if (first.isDescendantOf(parent) == true)
+		if (first.isDescendantOf(parent))
 		{
 			return true;
 		}
@@ -767,7 +767,7 @@ namespace BALL
 		// abort if a self-insertion is requested, there`s no parent at all,
 		// or this node is a descendant of composite
 		if (parent_ == 0 || &composite == this
-				|| isDescendantOf(composite) == true)
+				|| isDescendantOf(composite))
 		{
 			return;
 		}
@@ -827,7 +827,7 @@ namespace BALL
 		// abort if there`s no parent, on self-insertion, or
 		// if this node is a descendant of composite
 		if (parent_ == 0 || &composite == this
-				|| isDescendantOf(composite) == true)
+				|| isDescendantOf(composite))
 		{
 			return;
 		}
@@ -895,7 +895,7 @@ namespace BALL
 	{
 		// avoid self-splicing and the splicing of nodes that are
 		// descendants of composite
-		if (&composite == this || isDescendantOf(composite) == true)
+		if (&composite == this || isDescendantOf(composite))
 		{
 			return;
 		}
@@ -952,7 +952,7 @@ namespace BALL
 	{
 		// avoid self-splicing and the splicing of nodes that are
 		// descendants of composite
-		if (&composite == this || isDescendantOf(composite) == true)
+		if (&composite == this || isDescendantOf(composite))
 		{
 			return;
 		}
@@ -1008,7 +1008,7 @@ namespace BALL
 	void Composite::splice(Composite& composite)
 	{
 		// avoid self-splicing and splicing of descendants of composite
-		if (&composite == this|| isDescendantOf(composite) == true)
+		if (&composite == this|| isDescendantOf(composite))
 		{
 			return;
 		}
@@ -1098,7 +1098,7 @@ namespace BALL
 	bool Composite::removeChild(Composite& child)
 	{
 		// avoid self-removal and removal of ancestors
-		if (&child == this || isDescendantOf(child) == true)
+		if (&child == this || isDescendantOf(child))
 		{
 			return false;
 		}
@@ -1283,7 +1283,7 @@ namespace BALL
 			parent_->removeChild(*this);
 		}
 
-		if (virtual_flag == true)
+		if (virtual_flag)
 		{
 			clear();
 			stamp(MODIFICATION);
@@ -1296,8 +1296,8 @@ namespace BALL
 
 	void Composite::swap(Composite& composite)
 	{
-		if (&composite == this || isAncestorOf(composite) == true
-				|| isDescendantOf(composite) == true)
+		if (&composite == this || isAncestorOf(composite)
+				|| isDescendantOf(composite))
 		{
 			return;
 		}
@@ -1720,7 +1720,7 @@ namespace BALL
 				}
 			}
 
-			if (composite->first_child_ != 0  && composite->applyDescendantPreorderNostart_(processor) == false)
+			if (composite->first_child_ != 0  && !composite->applyDescendantPreorderNostart_(processor))
 			{
 				return false;
 			}

--- a/source/CONCEPT/objectCreator.C
+++ b/source/CONCEPT/objectCreator.C
@@ -48,7 +48,7 @@ namespace BALL
 			
 	{
 		// initialize the PersistenceManager only one times
-		if (init_ == false)
+		if (!init_)
 		{
 			init_ = true;
 

--- a/source/DATATYPE/bitVector.C
+++ b/source/DATATYPE/bitVector.C
@@ -272,7 +272,7 @@ namespace BALL
 		for (Index i = (Index)std::min((Size)BALL_CHAR_BITS, getSize()) - 1; i >= 0; i--)
 		{
 			c = c << 1;
-			if (getBit((Index)i) == true)
+			if (getBit((Index)i))
 			{
 				c |= 1;
 			}
@@ -300,7 +300,7 @@ namespace BALL
 		for (; i >= 0; i--)
 		{
 			c = c << 1;
-			if (getBit((Index)i) == true)
+			if (getBit((Index)i))
 			{
 				c |= 1;
 			}
@@ -329,7 +329,7 @@ namespace BALL
 		for (; i >= 0; i--)
 		{
 			c = c << 1;
-			if (getBit((Index)i) == true)
+			if (getBit((Index)i))
 			{
 				c |= 1;
 			}
@@ -358,7 +358,7 @@ namespace BALL
 		for (; i >= 0; i--)
 		{
 			c = c << 1;
-			if (getBit((Index)i) == true)
+			if (getBit((Index)i))
 			{
 				c |= 1;
 			}

--- a/source/DATATYPE/options.C
+++ b/source/DATATYPE/options.C
@@ -115,12 +115,7 @@ namespace BALL
 
 		// try to interpret the string as three double values
 		double dummy;
-		if (sscanf(get(key).c_str(), "(%lf %lf %lf)", &dummy, &dummy, &dummy) == 3)
-		{
-			return true;
-		}
-		
-		return false;
+		return sscanf(get(key).c_str(), "(%lf %lf %lf)", &dummy, &dummy, &dummy) == 3;
 	}
 
 	bool Options::isBool(const String& key) const
@@ -154,13 +149,7 @@ namespace BALL
 		double double_value   = ::atof(get(key).c_str());
 
 		// check if it is an integer (cutoff is 1e-7)
-		if (fabs(double_value - ((double)long_value)) <= 1e-7)
-		{
-			return true;
-		}
-
-		// it is a floating point number, but no integer
-		return false;
+		return fabs(double_value - ((double)long_value)) <= 1e-7;
 	}
 
 
@@ -216,14 +205,7 @@ namespace BALL
 		}
 
 		ConstIterator it = find(key);
-		if ((it != end()) && (it->second == "true" || it->second == "1"))
-		{
-			return true;
-		}
-		else 
-		{
-			return false;
-		}
+		return (it != end()) && (it->second == "true" || it->second == "1");
 	}
 
 	long Options::getInteger(const String& key) const

--- a/source/DATATYPE/regularExpression.C
+++ b/source/DATATYPE/regularExpression.C
@@ -49,7 +49,7 @@ namespace BALL
 			valid_pattern_(false)
 	{
 		memset(&regex_, 0, sizeof(regex_t));
-		if (wildcard_pattern == true)
+		if (wildcard_pattern)
 		{
 			toExtendedRegularExpression_();
 		}
@@ -85,7 +85,7 @@ namespace BALL
 
 	bool RegularExpression::match(const String& text, Index from, int execute_flags) const
 	{
-		if (valid_pattern_ == false)
+		if (!valid_pattern_)
 		{
 			return false;
 		}
@@ -105,7 +105,7 @@ namespace BALL
 
 	bool RegularExpression::match(const Substring& text, Index from, int execute_flags) const 
 	{
-		if (valid_pattern_ == false)
+		if (!valid_pattern_)
 		{
 			return false;
 		}
@@ -136,7 +136,7 @@ namespace BALL
 
 	bool RegularExpression::match(const char* text, int execute_flags) const
 	{
-		if (valid_pattern_ == false)
+		if (!valid_pattern_)
 		{
 			return false;
 		}
@@ -152,7 +152,7 @@ namespace BALL
 	bool RegularExpression::find(const String& text, Substring& found,
 															 Index from, int execute_flags) const
 	{
-		if ((valid_pattern_ == false) || (text.size() == 0))
+		if ((!valid_pattern_) || (text.size() == 0))
 		{
 			return false;
 		}
@@ -182,7 +182,7 @@ namespace BALL
 	bool RegularExpression::find(const String& text, vector<Substring>& subexpressions,
 															 Index from, int execute_flags) const
 	{
-		if (valid_pattern_ == false)
+		if (!valid_pattern_)
 		{
 			return false;
 		}

--- a/source/DATATYPE/string.C
+++ b/source/DATATYPE/string.C
@@ -127,7 +127,7 @@ namespace BALL
 
 	ostream& operator << (ostream &s, const Substring& substring)
 	{
-		if (substring.isBound() == false)
+		if (!substring.isBound())
 		{
 			return s;
 		}
@@ -167,7 +167,7 @@ namespace BALL
 	void* String::create(bool /* deep */, bool empty) const
 	{
 		void* ptr;
-		if (empty == true)
+		if (empty)
 		{
 			ptr = (void*)new String;
 		} 
@@ -380,13 +380,13 @@ namespace BALL
 		if (str_index != string::npos)
 		{
 			Size index = (Index)str_index;
-			if (!(c_str()[index] == '0' && (isWhitespace(c_str()[index + 1]) == true || c_str()[index + 1] == '\0'))
+			if (!(c_str()[index] == '0' && (isWhitespace(c_str()[index + 1]) || c_str()[index + 1] == '\0'))
 					&& !(c_str()[index++] == 'f'
 					&& c_str()[index++] == 'a'
 					&& c_str()[index++] == 'l'
 					&& c_str()[index++] == 's'
 					&& c_str()[index++] == 'e'
-					&& (isWhitespace(c_str()[index]) == true || c_str()[index] == '\0')))
+					&& (isWhitespace(c_str()[index]) || c_str()[index] == '\0')))
 			{
 				return true;
 			}

--- a/source/DOCKING/COMMON/conformation.C
+++ b/source/DOCKING/COMMON/conformation.C
@@ -250,8 +250,7 @@ namespace BALL
 
 	bool Conformation::checkID(String& hash)
 	{
-		if (id_ != hash) return false;
-		else return true;
+		return id_ == hash;
 	}
 
 	const AtomContainer* Conformation::getParent()

--- a/source/DOCKING/geometricFit.C
+++ b/source/DOCKING/geometricFit.C
@@ -1189,7 +1189,7 @@ void GeometricFit::doPreTranslation_( ProteinIndex pro_idx )
 		// calculate all the rotation angles
 		RotationAngles_ rotAng;
 
-		if(     rotAng.generateSomeAngles( (float)options.getReal(Option::DEG_PHI),
+		if(     !rotAng.generateSomeAngles( (float)options.getReal(Option::DEG_PHI),
 																			 (float)options.getReal(Option::DEG_PSI),
 																			 (float)options.getReal(Option::DEG_THETA),
 																			 (float)options.getReal(Option::PHI_MIN),
@@ -1197,7 +1197,7 @@ void GeometricFit::doPreTranslation_( ProteinIndex pro_idx )
 																			 (float)options.getReal(Option::PSI_MIN),
 																			 (float)options.getReal(Option::PSI_MAX),
 																			 (float)options.getReal(Option::THETA_MIN),
-																			 (float)options.getReal(Option::THETA_MAX) ) == false
+																			 (float)options.getReal(Option::THETA_MAX) )
 				||  rotAng.getRotationNum() == 0 )
 		{
 			Log.error() << "Bad degree interval!" << endl;

--- a/source/FORMAT/CIFFile.C
+++ b/source/FORMAT/CIFFile.C
@@ -643,8 +643,7 @@ namespace BALL
 
 	bool CIFFile::Datablock::hasSaveframeName(const String& name) const 
 	{
-		if (saveframe_names.has(name))	return true;
-		else  return false;
+		return saveframe_names.has(name);
 				
 	}
 
@@ -652,14 +651,12 @@ namespace BALL
 	{
 		//std::cout << " hasSaveframeCategory(): looking for " << name  
 		//					<< " " << saveframe_categories.count(name) << std::endl;
-		if (saveframe_categories.count(name)>0)	return true;
-		else  return false;
+		return saveframe_categories.count(name)>0;
 	}
 	
 	bool CIFFile::Datablock::hasItem(const String& name) const 
 	{
-		if (item_names.has(name))	return true;
-		else  return false;
+		return item_names.has(name);
 	}
 	
 	struct CIFFile::State CIFFile::state;

--- a/source/FORMAT/DCDFile.C
+++ b/source/FORMAT/DCDFile.C
@@ -730,9 +730,8 @@ namespace BALL
 		{
 			v[atom].z = readFloat_();
 		}
-		if (!readSize_(expected_size, "Z")) return false;
 
-		return true;
+		return readSize_(expected_size, "Z") != 0;
 	}
 
 

--- a/source/FORMAT/PDBFileDetails.C
+++ b/source/FORMAT/PDBFileDetails.C
@@ -164,7 +164,7 @@ namespace BALL
 				
 				delete_helix = !Composite::insertParent(**helix_it, *initial, *terminal, false);
 			}
-			if (delete_helix == true)
+			if (delete_helix)
 			{
 				delete (*helix_it);
 			}			
@@ -287,14 +287,14 @@ namespace BALL
 			for (protein_res_it = chain_it->beginResidue();
 					 +protein_res_it; ++protein_res_it)
 			{
-				if ((*protein_res_it).hasProperty(Residue::PROPERTY__AMINO_ACID) == true
-						&& (*protein_res_it).Composite::hasAncestor(RTTI::getDefault<SecondaryStructure>()) == false)
+				if ((*protein_res_it).hasProperty(Residue::PROPERTY__AMINO_ACID)
+						&& !(*protein_res_it).Composite::hasAncestor(RTTI::getDefault<SecondaryStructure>()))
 				{
 					terminal_residue = initial_residue = &(*protein_res_it);
 		
 					for (; !protein_res_it.isEnd()
-							 && (*protein_res_it).hasProperty(Residue::PROPERTY__AMINO_ACID) == true
-							 && (*protein_res_it).hasAncestor(RTTI::getDefault<SecondaryStructure>()) == false;
+							 && (*protein_res_it).hasProperty(Residue::PROPERTY__AMINO_ACID)
+							 && !(*protein_res_it).hasAncestor(RTTI::getDefault<SecondaryStructure>());
 							 ++protein_res_it)
 					{
 						terminal_residue = &(*protein_res_it);
@@ -305,7 +305,7 @@ namespace BALL
 		
 					Composite::insertParent(*sec_struc, *initial_residue, *terminal_residue, false);
 		
-					if (protein_res_it.isEnd() == true)
+					if (protein_res_it.isEnd())
 					{
 						break;
 					}
@@ -352,7 +352,7 @@ namespace BALL
 			residue_sequence_number_ = record.residue.sequence_number;
 			insertion_code_ = record.residue.insertion_code;
 			
-			if (current_residue_->hasProperty(Residue::PROPERTY__NON_STANDARD) == false)
+			if (!current_residue_->hasProperty(Residue::PROPERTY__NON_STANDARD))
 			{
 				current_residue_->setProperty(Residue::PROPERTY__AMINO_ACID);
 			}
@@ -415,7 +415,7 @@ namespace BALL
 		record.charge[0] = '\0';
 		record.partial_charge[0] = '\0';
 
-		if (parse_partial_charges_ == true)
+		if (parse_partial_charges_)
 		{
 			return parseLine
 				(line, size, 
@@ -473,7 +473,7 @@ namespace BALL
 		{
 			return false;
 		}
-		if ((ignore_xplor_pseudo_atoms_ == true)
+		if (ignore_xplor_pseudo_atoms_
 				&& record.orthogonal_vector[0] >= 9998.0
 				&& record.orthogonal_vector[1] >= 9998.0
 				&& record.orthogonal_vector[2] >= 9998.0)
@@ -730,7 +730,7 @@ namespace BALL
 		current_PDB_atom_->setProperty(PDBAtom::PROPERTY__HETATM);
 		
 		static RegularExpression regular_expression("^OHH|HOH|HHO|H2O|2HO|OH2|SOL|TIP|TIP2|TIP3|TIP4|WAT|D2O$");
-		if (regular_expression.match(current_residue_->getName()) == true)
+		if (regular_expression.match(current_residue_->getName()))
 		{
 			current_residue_->setProperty(Residue::PROPERTY__WATER);
 		}
@@ -1160,7 +1160,7 @@ namespace BALL
 	{
 		Protein* protein = new Protein;
 		bool result = read(*protein);
-		if (result == true)
+		if (result)
 		{
 			molecule = *protein;
 		}
@@ -1173,7 +1173,7 @@ namespace BALL
 	{
 		Protein* protein = new Protein;
 		bool result = read(*protein);
-		if (result == false)
+		if (!result)
 		{
 			delete protein;
 		}

--- a/source/FORMAT/PDBFileGeneral.C
+++ b/source/FORMAT/PDBFileGeneral.C
@@ -181,7 +181,7 @@ namespace BALL
 		streampos old_pos = tellg();
 		Size size = 0;
 
-		if (from_begin_of_file == true)
+		if (from_begin_of_file)
 		{
 			readFirstRecord(false);
 		}
@@ -213,7 +213,7 @@ namespace BALL
 		streampos old_pos = tellg();
 		Size size = 0;
 
-		if (from_begin_of_file == true)
+		if (from_begin_of_file)
 		{
 			readFirstRecord(false);
 		}
@@ -264,7 +264,7 @@ namespace BALL
 		
 		// The PDB format description says: "Each line in the PDB entry file
 		// consists of 80 columns." 
-		if (strict_line_checking_ == true)
+		if (strict_line_checking_)
 		{
 			if (size <= PDB::SIZE_OF_PDB_RECORD_LINE)
 			{ 
@@ -326,7 +326,7 @@ namespace BALL
 	bool PDBFile::skipCurrentRecord()
 	{
 		// Store skipped stuff only if the corresponding flag is set
-		if (store_skipped_records_ == true)
+		if (store_skipped_records_)
 		{
 			info.getSkippedRecords().push_back(line_buffer_);
 		}
@@ -519,7 +519,7 @@ namespace BALL
 		// If we do not want to extract the values, it is sufficient
 		// to know that the record type is something we know how to
 		// handle, so we are done now.
-		if (extract_values == false)
+		if (!extract_values)
 		{
 			return true;
 		}

--- a/source/FORMAT/commandlineParser.C
+++ b/source/FORMAT/commandlineParser.C
@@ -774,8 +774,8 @@ void CommandlineParser::parse(int argc, char* argv[])
 	set<String> missing_parameters;
 	for (map < String, ParameterDescription > :: iterator it = registered_parameters_.begin(); it != registered_parameters_.end(); it++)
 	{
-		if (it->second.mandatory == false) 
-  	{
+		if (!it->second.mandatory)
+		{
 			continue;
 		}
 		if (parameter_map_.find(it->second.name) == parameter_map_.end())
@@ -917,14 +917,7 @@ const String& CommandlineParser::get(String name)
 
 bool CommandlineParser::has(String name)
 {
-	if (get(name) != NOT_FOUND)
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+	return get(name) != NOT_FOUND;
 }
 
 

--- a/source/FORMAT/resourceFile.C
+++ b/source/FORMAT/resourceFile.C
@@ -38,7 +38,7 @@ namespace BALL
 			child_(0),
 			number_children_(0)
 	{
-		if (deep == true)
+		if (deep)
 		{
 			ResourceEntry* cloned = entry.clone_(0);
 
@@ -184,7 +184,7 @@ namespace BALL
 		
 		if (entry != 0)
 		{
-			if (replace_value == true)
+			if (replace_value)
 			{
 				entry->value_ = value;
 			}
@@ -241,7 +241,7 @@ namespace BALL
 
 	ResourceEntry* ResourceEntry::insertChild(ResourceEntry& entry, bool replace_value)
 	{
-		if (&entry == this || entry.isAncestorOf(*this) == true)
+		if (&entry == this || entry.isAncestorOf(*this))
 		{
 			return 0;
 		}
@@ -260,7 +260,7 @@ namespace BALL
 		{
 			entry_ptr->clear();
 
-			if (replace_value == true)
+			if (replace_value)
 			{
 				entry_ptr->value_ = entry.value_;
 			}
@@ -357,7 +357,7 @@ namespace BALL
 
 	bool ResourceEntry::mergeChildrenOf(ResourceEntry& resource_entry, bool replace_value)
 	{
-		if (&resource_entry == this || resource_entry.isAncestorOf(*this) == true)
+		if (&resource_entry == this || resource_entry.isAncestorOf(*this))
 		{
 			return false;
 		}
@@ -374,7 +374,7 @@ namespace BALL
 	{
 		Index found = 0;
 		
-		if (findGreaterOrEqual_(key, found) == true)
+		if (findGreaterOrEqual_(key, found))
 		{
 			if (removed == 0)
 			{
@@ -509,7 +509,7 @@ namespace BALL
 
 			for (Index index = 0; index < (Index)number_children_; ++index)
 			{
-				if (child_[index]->isValid() == false)
+				if (!child_[index]->isValid())
 				{
 					return false;
 				}
@@ -563,10 +563,10 @@ namespace BALL
 			
 			if (result <= Processor::BREAK)
 			{
-				return (result == Processor::BREAK) ? true : false;
+				return result == Processor::BREAK;
 			}
 			
-			if (entry->number_children_ > 0 && entry->applyNostart_(processor) == false)
+			if (entry->number_children_ > 0 && !entry->applyNostart_(processor))
 			{
 				return false;
 			}
@@ -577,7 +577,7 @@ namespace BALL
 
 	bool ResourceEntry::applyChildren(UnaryProcessor<ResourceEntry>& processor)
 	{
-		if (processor.start() == false)
+		if (!processor.start())
 		{
 			return false;
 		}
@@ -590,7 +590,7 @@ namespace BALL
 			
 			if (result <= Processor::BREAK)
 			{
-				return (result == Processor::BREAK) ? true : false;
+				return result == Processor::BREAK;
 			}
 		}
 		
@@ -671,7 +671,7 @@ namespace BALL
 		
 		Size depth = 0;
 		
-		if (entry.isEmpty() == false)
+		if (!entry.isEmpty())
 		{
 			save_(file, &entry, depth);
 		}

--- a/source/KERNEL/PTE.C
+++ b/source/KERNEL/PTE.C
@@ -504,7 +504,7 @@ namespace BALL
  
 	Element& PTE_::getElement(const String& symbol)
 	{
-		if (symbol.isEmpty() == true)
+		if (symbol.isEmpty())
 		{
 			return Element::UNKNOWN;
 		}
@@ -548,7 +548,7 @@ namespace BALL
 
 	bool PTE_::apply(UnaryProcessor<Element>& processor)
 	{
-		if (processor.start() == false)
+		if (!processor.start())
 		{
 			return false;
 		}
@@ -561,7 +561,7 @@ namespace BALL
 
 			if (result <= Processor::BREAK)
 			{
-				return (result == Processor::BREAK) ? true : false;
+				return result == Processor::BREAK;
 			}
 		}
 

--- a/source/KERNEL/atom.C
+++ b/source/KERNEL/atom.C
@@ -389,7 +389,7 @@ namespace BALL
 			return false;
 		}
 
-		if (bond->isAutoDeletable() == true)
+		if (bond->isAutoDeletable())
 		{
 			delete bond;
 		}
@@ -405,7 +405,7 @@ namespace BALL
 	{
 		for (int i = char(number_of_bonds_) - 1; i >= 0; --i)
 		{
-			if (bond_[i]->isAutoDeletable() == true)
+			if (bond_[i]->isAutoDeletable())
 			{
 				delete bond_[i];
 			}
@@ -521,8 +521,8 @@ namespace BALL
 
 	bool Atom::isValid() const
 	{
-		if (Composite::isValid() == false
-				|| PropertyManager::isValid() == false
+		if (!Composite::isValid()
+				|| !PropertyManager::isValid()
 				|| element_ == 0)
 		{
 			return false;
@@ -530,7 +530,7 @@ namespace BALL
 
 		for (int i = 0; i < number_of_bonds_; ++i)
 		{
-			if (bond_[i]->isValid() == false)
+			if (!bond_[i]->isValid())
 			{
 				return false;
 			}
@@ -597,7 +597,7 @@ namespace BALL
 	bool Atom::applyBonds(UnaryProcessor<Bond>& processor)
 
 	{
-		if (processor.start() == false)
+		if (!processor.start())
 		{
 			return false;
 		}
@@ -609,7 +609,7 @@ namespace BALL
 
 			if (result <= Processor::BREAK)
 			{
-				return (result == Processor::BREAK) ? true : false;
+				return result == Processor::BREAK;
 			}
 		}
 

--- a/source/KERNEL/atomContainer.C
+++ b/source/KERNEL/atomContainer.C
@@ -127,7 +127,7 @@ namespace BALL
 		for (Composite::AncestorIterator ancestor_it = beginAncestor();
 				 !ancestor_it.isEnd(); ++ancestor_it)
 		{
-            if (RTTI::isKindOf<AtomContainer>(&*ancestor_it) == true)
+            if (RTTI::isKindOf<AtomContainer>(&*ancestor_it))
 			{
 				return (AtomContainer *)&*ancestor_it;
 			}
@@ -448,7 +448,7 @@ namespace BALL
 
 	bool AtomContainer::applyInterBond(UnaryProcessor<Bond>& processor)
 	{
-		if (processor.start() == false)
+		if (!processor.start())
 		{
 			return false;
 		}
@@ -463,7 +463,7 @@ namespace BALL
 
 			if (result <= Processor::BREAK)
 			{
-				return (result == Processor::BREAK) ? true : false;
+				return result == Processor::BREAK;
 			}
 		}
 
@@ -472,7 +472,7 @@ namespace BALL
 
 	bool AtomContainer::applyIntraBond(UnaryProcessor<Bond> &processor)
 	{
-    if (processor.start() == false)
+    if (!processor.start())
 		{
       return false;
 		}
@@ -487,7 +487,7 @@ namespace BALL
 
 			if (result <= Processor::BREAK)
 			{
-				return (result == Processor::BREAK) ? true : false;
+				return result == Processor::BREAK;
 			}
 		}
 

--- a/source/KERNEL/chain.C
+++ b/source/KERNEL/chain.C
@@ -69,7 +69,7 @@ namespace BALL
 		for (Composite::AncestorIterator ancestor_it = beginAncestor();
 				 !ancestor_it.isEnd(); ++ancestor_it)
 		{
-            if (RTTI::isKindOf<Protein>(&*ancestor_it) == true)
+            if (RTTI::isKindOf<Protein>(&*ancestor_it))
 			{
 				return (Protein *)&*ancestor_it;
 			}

--- a/source/KERNEL/expressionTree.C
+++ b/source/KERNEL/expressionTree.C
@@ -172,7 +172,7 @@ namespace BALL
 				// OR expressions may be aborted, if the first subexpression yields true
         if (type_ == OR)
         {
-          if (result == true)
+          if (result)
           {
             abort = true;
 					}
@@ -181,7 +181,7 @@ namespace BALL
 				{
 					// AND expressions may be aborted, if the first subexpression
 					// yields false
-          if (result == false)
+          if (!result)
           {
             abort = true;
 					}

--- a/source/KERNEL/molecularInteractions.C
+++ b/source/KERNEL/molecularInteractions.C
@@ -77,8 +77,7 @@ bool MolecularInteractions::hasInteraction(const Atom* atom, String interaction_
 	map<String, map<const Atom*,double> >::const_iterator search_it = interactions_map_.find(interaction_type);
 	if(search_it==interactions_map_.end()) return false;
 
-	if(search_it->second.find(atom)!=search_it->second.end()) return true;
-	else return false;
+	return search_it->second.find(atom)!=search_it->second.end();
 }
 
 

--- a/source/KERNEL/molecule.C
+++ b/source/KERNEL/molecule.C
@@ -74,7 +74,7 @@ namespace BALL
 		for (Composite::AncestorIterator ancestor_it = beginAncestor();
 				 !ancestor_it.isEnd(); ++ancestor_it)
 		{
-            if (RTTI::isKindOf<System>(&*ancestor_it) == true)
+            if (RTTI::isKindOf<System>(&*ancestor_it))
 			{
 				return (System *)&*ancestor_it;
 			}

--- a/source/KERNEL/residue.C
+++ b/source/KERNEL/residue.C
@@ -466,7 +466,7 @@ namespace BALL
 
 	bool Residue::isNTerminal() const
 	{
-		if (isAminoAcid() == true)
+		if (isAminoAcid())
 		{
 			const Chain* chain = getChain();
 
@@ -484,7 +484,7 @@ namespace BALL
 		
 	bool Residue::isCTerminal() const
 	{
-		if (isAminoAcid() == true)
+		if (isAminoAcid())
 		{
 			const Chain* chain = getChain();
 

--- a/source/KERNEL/standardPredicates.C
+++ b/source/KERNEL/standardPredicates.C
@@ -264,20 +264,10 @@ namespace BALL
 		{
 			RingFinder find_my_ring(n);
 
-			if (find_my_ring(atom) == true)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-		else
-		{
-			return(false);
+			return find_my_ring(atom);
 		}
 
+		return false;
 	}
 
 	NumberOfBondsPredicate::NumberOfBondsPredicate()
@@ -329,34 +319,13 @@ namespace BALL
 			switch (s[0]) 
 			{
 				case '<' :
-					if (count < n)
-					{
-						return true;
-					}
-					else
-					{
-						return false;
-					}
+					return count < n;
 
 				case '>' :
-					if (count > n)
-					{
-						return true;
-					}
-					else 
-					{
-						return false;
-					}
+					return count > n;
 
 				case '=':
-					if (count == n)
-					{
-						return true;
-					}
-					else 
-					{
-						return false;
-					}
+					return count == n;
 
 				default:
 					Log.error() << "NumberOfBondsPredicate::testPredicate_(): Illegal operator " 
@@ -376,14 +345,7 @@ namespace BALL
 					<< "argument format is broken: " << argument_ << std::endl;
 				return(false);
 			}
-			if (count == n)
-			{
-				return true;
-			}
-			else 
-			{
-				return false;
-			}
+			return count == n;
 		}
 	}
 
@@ -451,34 +413,13 @@ namespace BALL
 			switch (s[0]) 
 			{
 				case '<' :
-					if (count < n)
-					{
-						return true;
-					}
-					else
-					{
-						return false;
-					}
+					return count < n;
 
 				case '>' :
-					if (count > n)
-					{
-						return true;
-					}
-					else 
-					{
-						return false;
-					}
+					return count > n;
 
 				case '=':
-					if (count == n)
-					{
-						return true;
-					}
-					else 
-					{
-						return false;
-					}
+					return count == n;
 
 				default:
 					Log.error() << "AromaticBondsPredicate::testPredicate_(): Illegal operator " 
@@ -498,14 +439,7 @@ namespace BALL
 					<< "argument format is broken: " << argument_ << std::endl;
 				return(false);
 			}
-			if (count == n)
-			{
-				return true;
-			}
-			else 
-			{
-				return false;
-			}
+			return count == n;
 		}
 	}
 
@@ -985,7 +919,7 @@ namespace BALL
 						{
 							if (lowercase.has(input[position]))
 							{
-								if (current->isFinished() == true)
+								if (current->isFinished())
 								{
 									Log.error() << "ConnectedToPredicate::parse_():\n"
 										<< "\tparse error: trying to add a lowercase char to an already finished node." 
@@ -1018,7 +952,7 @@ namespace BALL
 									if (numbers.has(link_mark_))
 									{
 
-										if (link_map_.has(link_mark_) == true)
+										if (link_map_.has(link_mark_))
 										{
 											if (link_map_[link_mark_].second != 0)
 											{
@@ -1179,28 +1113,23 @@ namespace BALL
 				break;
 
 			case CTPNode::BONDTYPE__SINGLE:
-				if (bond.getOrder() == Bond::ORDER__SINGLE) result = true;
-				else result = false;
+				result = bond.getOrder() == Bond::ORDER__SINGLE;
 				break;
 
 			case CTPNode::BONDTYPE__DOUBLE:
-				if (bond.getOrder() == Bond::ORDER__DOUBLE) result = true;
-				else result = false;
+				result = bond.getOrder() == Bond::ORDER__DOUBLE;
 				break;
 
 			case CTPNode::BONDTYPE__TRIPLE:
-				if (bond.getOrder() == Bond::ORDER__TRIPLE) result = true;
-				else result = false;
+				result = bond.getOrder() == Bond::ORDER__TRIPLE;
 				break;
 
 			case CTPNode::BONDTYPE__QUADRUPLE:
-				if (bond.getOrder() == Bond::ORDER__QUADRUPLE) result = true;
-				else result = false;
+				result = bond.getOrder() == Bond::ORDER__QUADRUPLE;
 				break;
 
 			case CTPNode::BONDTYPE__AROMATIC:
-				if (bond.isAromatic()) result = true;
-				else result = false;
+				result = bond.isAromatic();
 				break;
 
 			default:
@@ -1240,9 +1169,9 @@ namespace BALL
 			for (Size j = 0; j < atom.countBonds(); ++j)
 			{
 				bond = atom.getBond(j);
-				if (visited.has(bond) == false)
+				if (!visited.has(bond))
 				{
-					if (bondOrderMatch_(*bond, **child_it) == true)
+					if (bondOrderMatch_(*bond, **child_it))
 					{
 						partner = bond->getPartner(atom);
 						if (((*child_it)->getSymbol() == "*")
@@ -1257,7 +1186,7 @@ namespace BALL
 						{
 							visited.insert(bond);
 							this_result = find_(*partner, *child_it, visited);
-							if (this_result == true)
+							if (this_result)
 							{
 								if (verbosity > 90)
 								{
@@ -1275,7 +1204,7 @@ namespace BALL
 				}
 			}
 
-			if (this_result == false)
+			if (!this_result)
 			{
 				return(false);
 			}
@@ -1361,14 +1290,7 @@ namespace BALL
 				tcount++;
 			}
 		}
-		if ((dcount == 2) || (tcount == 1))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return (dcount == 2) || (tcount == 1);
 	}
 
 	bool Sp2HybridizedPredicate::operator () (const Atom& atom) const
@@ -1387,14 +1309,7 @@ namespace BALL
 				acount++;
 			}
 		}
-		if ((dcount == 1) || (acount > 1))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return (dcount == 1) || (acount > 1);
 	}
 
 	bool Sp3HybridizedPredicate::operator () (const Atom& atom) const
@@ -1490,7 +1405,7 @@ namespace BALL
 
 		// make sure we are in a 5 or 6 memebered ring.
 		RingFinder in_ring;
-		if (!in_ring(atom) == true)
+		if (!in_ring(atom))
 		{
 #ifdef DEBUG
 			std::cout << "Not in a ring." << std::endl;
@@ -1605,18 +1520,9 @@ namespace BALL
 			<< fabs(angle_C1_R) - 109.5 << std::endl;
 #endif
 
-		if ((fabs(angle_C1_H) < 15.0) 
-				&& ((fabs(angle_C1_R) - 109.5) < 15.0))
-		{
-			// if the hydrogen stands in axial position and the substituent in
-			// equatorial position the carbon is equatorially substituted
-			return(false);
-		}
-		else
-		{
-			return(true);
-		}
-
+		// if the hydrogen stands in axial position and the substituent in
+		// equatorial position the carbon is equatorially substituted
+		return fabs(angle_C1_H) >= 15.0 || fabs(angle_C1_R) - 109.5 >= 15.0;
 	}
 
 	bool Conformation4C1Predicate::operator () (const Atom& atom) const
@@ -1689,14 +1595,7 @@ namespace BALL
 		std::cout << "d * n: " << d * n << std::endl;
 #endif
 
-		if ((d * n) > 0)
-		{
-			return(false);
-		}
-		else
-		{
-			return(true);
-		}
+		return (d * n) <= 0;
 	}
 
 
@@ -1755,20 +1654,11 @@ namespace BALL
 		// the following recursive function performs an ad-hoc dfs and returns
 		// true, if a ring was found and false otherwise.
 
-		if (exact_ == true)
+		if (exact_)
 		{
 			if (limit == 0) 
 			{
-				if (atom == *first_atom_) 
-				{
-					// Found first atom at limit
-					return true;
-				}
-				else
-				{
-					// Reached limit without finding the first atom
-					return false;
-				}
+				return atom == *first_atom_;
 			}
 		}
 		else
@@ -1796,7 +1686,7 @@ namespace BALL
 			{
 				descend = bond->getPartner(atom);
 				visited_bonds_.insert(bond);
-				if (dfs(*descend, limit-1) == true)
+				if (dfs(*descend, limit-1))
 				{
 // #ifdef DEBUG
 // 					std::cout << "Pushing back " << atom.getFullName() << std::endl;

--- a/source/MATHS/piecewiseFunction.C
+++ b/source/MATHS/piecewiseFunction.C
@@ -221,14 +221,7 @@ namespace BALL
 
 	bool PiecewiseFunction::isInRange(double x) const 
 	{
-		if ((x >= range_.first) && (x < range_.second))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return (x >= range_.first) && (x < range_.second);
 	}
 
 

--- a/source/MOLMEC/AMBER/amberBend.C
+++ b/source/MOLMEC/AMBER/amberBend.C
@@ -67,7 +67,7 @@ namespace BALL
 		{
 			result = bend_parameters.extractSection(getForceField()->getParameters(), "QuadraticAngleBend");
 
-			if (result == false) 
+			if (!result)
 			{
 				Log.error() << "AmberBend::setup: cannot find section QuadraticAngleBend" << endl;
 				return false;
@@ -92,11 +92,10 @@ namespace BALL
 					this_bend.atom2 = (*atom_it);
 					this_bend.atom3 = it1->getPartner(**atom_it);
 
-					if ((use_selection == false) ||
-					   (use_selection == true &&
-					   (   this_bend.atom1->isSelected()
-							&& this_bend.atom2->isSelected()
-							&& this_bend.atom3->isSelected())))
+					if (!use_selection || (use_selection
+						&& this_bend.atom1->isSelected()
+						&& this_bend.atom2->isSelected()
+						&& this_bend.atom3->isSelected()))
 					{ 
 
 						Atom::Type atom_type_a1 = this_bend.atom1->getType();

--- a/source/MOLMEC/AMBER/amberNonBonded.C
+++ b/source/MOLMEC/AMBER/amberNonBonded.C
@@ -919,7 +919,7 @@ namespace BALL
     Vector3 direction(atom1->getPosition() - atom2->getPosition());
 
     // choose the nearest image if period boundary is enabled 
-    if (use_periodic_boundary == true)
+    if (use_periodic_boundary)
 		{
 			AMBERcalculateMinimumImage(direction, period); 
 		}
@@ -1263,7 +1263,7 @@ namespace BALL
 		// calculate forces arising from 1-4 interaction pairs
 		// and remaining non-bonded interaction pairs
 
-		if ((use_periodic_boundary == true) && (use_dist_depend_dielectric_ == true))
+		if (use_periodic_boundary && use_dist_depend_dielectric_)
 		{
 			// periodic boundary is enabled; use a distance dependent dielectric
 			// constant 
@@ -1290,8 +1290,7 @@ namespace BALL
 		}
 		else
 		{
-			if ((use_periodic_boundary == true)
-					&& (use_dist_depend_dielectric_ == false))
+			if (use_periodic_boundary && !use_dist_depend_dielectric_)
 			{
 				// periodic boundary is enabled; use a distance dependent
 				// dielectric constant 
@@ -1319,8 +1318,7 @@ namespace BALL
 			}
 			else
 			{
-				if ((use_periodic_boundary == false) 
-						&& (use_dist_depend_dielectric_ == true))
+				if (!use_periodic_boundary && use_dist_depend_dielectric_)
 				{
 					// periodic boundary not enabled; use a distance dependent
 					// dielectric constant 

--- a/source/MOLMEC/AMBER/amberTorsion.C
+++ b/source/MOLMEC/AMBER/amberTorsion.C
@@ -152,9 +152,11 @@ namespace BALL
 										a4 = const_cast<Atom*>(it3->getFirstAtom());
 									}
 
-									if ((use_selection == false) 
-											|| ((use_selection == true) 
-													&& (a1->isSelected() && a2->isSelected() && a3->isSelected() && a4->isSelected())))
+									if (!use_selection || (use_selection
+									    && a1->isSelected()
+									    && a2->isSelected()
+									    && a3->isSelected()
+									    && a4->isSelected()))
 									{
 										// search torsion parameters for (a1,a2,a3,a4)
 										Atom::Type type_a1 = a1->getType();
@@ -230,7 +232,7 @@ namespace BALL
 		if (!has_initialized_parameters)
 		{
 			result = impropers_.extractSection(getForceField()->getParameters(), "ResidueImproperTorsions");
-			if (result == false)
+			if (!result)
 			{
 				Log.error() << "cannot find section ResidueImproperTorsions" << endl;
 				return false;
@@ -320,9 +322,11 @@ namespace BALL
 								if (a1->getTypeName() > a4->getTypeName()) swap(a1, a4);
 								if (a2->getTypeName() > a4->getTypeName()) swap(a2, a4);
 
-								if	((use_selection == false) ||
-										 ((use_selection == true) &&
-											(a1->isSelected() && a2->isSelected() && a3->isSelected() && a4->isSelected())))
+								if (!use_selection || (use_selection
+								    && a1->isSelected()
+								    && a2->isSelected()
+								    && a3->isSelected()
+								    && a4->isSelected()))
 								{
 									Atom::Type type_a1 = a1->getType();
 									Atom::Type type_a2 = a2->getType();
@@ -395,10 +399,9 @@ namespace BALL
 			const Atom* atom3 = it->atom3;
 			const Atom* atom4 = it->atom4;
 
-			if ((use_selection == false) ||
-					((use_selection == true) &&
-					(   atom1->isSelected() || atom2->isSelected()
-					 || atom3->isSelected() || atom4->isSelected())))
+			if (!use_selection || (use_selection &&
+			    (   atom1->isSelected() || atom2->isSelected()
+			     || atom3->isSelected() || atom4->isSelected())))
 			{
 				a21 = atom1->getPosition() - atom2->getPosition();
 				a23 = atom3->getPosition() - atom2->getPosition();
@@ -455,10 +458,9 @@ namespace BALL
 			Atom* atom3 = it->atom3;
 			Atom* atom4 = it->atom4;
 
-			if ((use_selection == false) ||
- 					((use_selection == true) &&
-					(   atom1->isSelected() || atom2->isSelected()
-					 || atom3->isSelected() || atom4->isSelected())))
+			if (!use_selection || (use_selection &&
+			    (   atom1->isSelected() || atom2->isSelected()
+			     || atom3->isSelected() || atom4->isSelected())))
 			{
 				ab = atom1->getPosition() - atom2->getPosition();
 				double length_ab = ab.getLength();
@@ -509,7 +511,7 @@ namespace BALL
 						Vector3 dEdu = - (float)(dEdphi / (length_u2 * cb.getLength())) * (u % cb);
 	
 
-						if (use_selection == false)
+						if (!use_selection)
 						{
 							atom1->getForce() += dEdt % cb;
 							atom2->getForce() += ca % dEdt + dEdu % dc;

--- a/source/MOLMEC/CHARMM/charmmBend.C
+++ b/source/MOLMEC/CHARMM/charmmBend.C
@@ -67,7 +67,7 @@ namespace BALL
 			bool result = false;
 			result = bend_parameters_.extractSection(getForceField()->getParameters(), "QuadraticAngleBend");
 
-			if (result == false) 
+			if (!result)
 			{
 				Log.error() << "cannot find section QuadraticAngleBend" << endl;
 				return false;
@@ -91,11 +91,10 @@ namespace BALL
 					this_bend.atom2 = (*atom_it);
 					this_bend.atom3 = (*it1).getPartner(**atom_it);
 
-					if (getForceField()->getUseSelection() == false ||
-					   (getForceField()->getUseSelection() == true && 
-					   (   this_bend.atom1->isSelected()
-							&& this_bend.atom2->isSelected()
-							&& this_bend.atom3->isSelected())))
+					if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection()
+					    && this_bend.atom1->isSelected()
+					    && this_bend.atom2->isSelected()
+					    && this_bend.atom3->isSelected()))
 					{ 
 
 						Atom::Type atom_type_a1 = this_bend.atom1->getType();

--- a/source/MOLMEC/CHARMM/charmmImproperTorsion.C
+++ b/source/MOLMEC/CHARMM/charmmImproperTorsion.C
@@ -90,7 +90,7 @@ namespace BALL
 		{
 			result = improper_parameters_.extractSection(getForceField()->getParameters(), "ImproperTorsions");
 
-			if (result == false) 
+			if (!result)
 			{
 				Log.error() << "cannot find section ImproperTorsions in parameter file" << endl;
 				return false;
@@ -103,7 +103,7 @@ namespace BALL
 		if (!has_initialized_parameters)
 		{
 			result = improper_atoms_.extractSection(getForceField()->getParameters(), "ResidueImproperTorsions");
-			if (result == false)
+			if (!result)
 			{
 				Log.error() << "cannot find section ResidueImproperTorsions" << endl;
 				return false;
@@ -301,9 +301,11 @@ namespace BALL
 				{
 					// if we use selection and the atoms are selected,
 					// add the torsion the the impropers_ vector
-					if	(getForceField()->getUseSelection() == false ||
-							 (getForceField()->getUseSelection() == true &&
-								(a1->isSelected() && a2->isSelected() && a3->isSelected() && a4->isSelected())))
+					if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection()
+					    && a1->isSelected()
+					    && a2->isSelected()
+					    && a3->isSelected()
+					    && a4->isSelected()))
 					{
 						Atom::Type type_a1 = a1->getType();
 						Atom::Type type_a2 = a2->getType();
@@ -407,9 +409,9 @@ namespace BALL
 
 		for ( ; it != impropers_.end(); it++) 
 		{
-			if ( getForceField()->getUseSelection() == false ||
-					( getForceField()->getUseSelection() == true &&
-					(it->atom1->isSelected() || it->atom2->isSelected() || it->atom3->isSelected() || it->atom4->isSelected())))
+			if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection() &&
+			    (   it->atom1->isSelected() || it->atom2->isSelected()
+			     || it->atom3->isSelected() || it->atom4->isSelected())))
 			{
 				ba = it->atom2->getPosition() - it->atom1->getPosition();
 				bc = it->atom2->getPosition() - it->atom3->getPosition();
@@ -463,9 +465,9 @@ namespace BALL
 
 		for (; it != impropers_.end(); it++) 
 		{
-			if (getForceField()->getUseSelection() == false ||
-					( getForceField()->getUseSelection() == true &&
-					(it->atom1->isSelected() || it->atom2->isSelected() || it->atom3->isSelected() || it->atom4->isSelected())))
+			if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection() &&
+			    (   it->atom1->isSelected() || it->atom2->isSelected()
+			     || it->atom3->isSelected() || it->atom4->isSelected())))
 			{
 
 				// A is the central atom
@@ -543,7 +545,7 @@ namespace BALL
 																	 +	((ilength_bcxba * ilength_bcxbd) * (bc2 * bd - bcbd * bc)));
 
 						// add the forces to the atoms' force vectors
-						if (getForceField()->getUseSelection() == false)
+						if (!getForceField()->getUseSelection())
 						{
 							it->atom1->getForce() += factor * dcosphi_dba;
 							it->atom2->getForce() -= factor * (dcosphi_dbc + dcosphi_dbd + dcosphi_dba);

--- a/source/MOLMEC/CHARMM/charmmNonBonded.C
+++ b/source/MOLMEC/CHARMM/charmmNonBonded.C
@@ -248,7 +248,7 @@ namespace BALL
 		{
 			bool result = van_der_waals_parameters_.extractSection(getForceField()->getParameters(), "LennardJones");
 
-			if (result == false) 
+			if (!result)
 			{	
 				Log.error() << "CharmmNonBonded::setup(): cannot find section LennardJones" << endl;
 				return false;
@@ -257,7 +257,7 @@ namespace BALL
 			// read 1-4 lennard jones parameters
 			result = van_der_waals_parameters_14_.extractSection(getForceField()->getParameters(), "LennardJones14");
 
-			if (result == false) 
+			if (!result)
 			{	
 				Log.error() << "CharmmNonBonded::setup(): cannot find section LennardJones14" << endl;
 				return false;
@@ -343,7 +343,7 @@ namespace BALL
 			{
 				bool result = solvation_parameters_.extractSection(getForceField()->getParameters(), "EEF1Solvation");
 
-				if (result == false)
+				if (!result)
 				{
 					Log.error() << "CharmmNonBonded::setup: cannot setup EEF1 solvation component." << endl;
 					return false;
@@ -669,7 +669,7 @@ namespace BALL
 
 		Vector3 difference(atom1->getPosition() - atom2->getPosition());
 
-		if (use_periodic_boundary == true)
+		if (use_periodic_boundary)
 		{
 			// calculate the minimum image if a periodic boundary is used
 			CHARMMcalculateMinimumImage(difference, period, half_period); 
@@ -788,7 +788,7 @@ namespace BALL
 		Vector3 direction(atom1->getPosition() - atom2->getPosition());
 
 		// choose the nearest image if period boundary is enabled 
-		if (use_periodic_boundary == true)
+		if (use_periodic_boundary)
 		{
 			CHARMMcalculateMinimumImage(direction, period, half_period); 
 		}
@@ -819,7 +819,7 @@ namespace BALL
 				// saves one if/then:
 				// factor evaluates to 1.0 if the distance dependent electrostatics
 				// are used and to 0.0 otherwise
-				double dist_depend_factor = (double)(use_dist_depend == true);
+				double dist_depend_factor = (double)(use_dist_depend);
 
 				// This expression evaluates to either 
 				//     inverse_distance * 2.0  (for distance dependent ES)
@@ -1074,7 +1074,7 @@ namespace BALL
 
 			for ( ; vector_it != getForceField()->getAtoms().end(); ++vector_it)	
 			{
-				if (use_selection == false || (use_selection == true  && (*vector_it)->isSelected()))
+				if (!use_selection || (use_selection  && (*vector_it)->isSelected()))
 				{
 					solvation_energy_ += solvation_[(*vector_it)->getType()].dG_ref;
 				}
@@ -1084,7 +1084,7 @@ namespace BALL
 		
 		// calculate energies arising from 1-4 interaction pairs 
 		// and remaining non-bonded interaction pairs 
-		if (use_periodic_boundary == true && use_dist_depend_dielectric_ == true)
+		if (use_periodic_boundary && use_dist_depend_dielectric_)
 		{
 			// Periodic boundary is enabled and use distance dependent dielectric 
 
@@ -1096,7 +1096,7 @@ namespace BALL
 			// first evaluate 1-4 non-bonded pairs 
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; ++it, i++)
 			{
-				if (use_selection == false || (use_selection == true && (it->atom1->isSelected() || it->atom2->isSelected())))
+				if (!use_selection || (use_selection && (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, true, true,
@@ -1107,7 +1107,7 @@ namespace BALL
 			// evaluate remaining non-bonded pairs (also in the same vector) 
 			for (i = 0; it != non_bonded_.end(); ++it, i++)
 			{
-				if (use_selection == false || ((use_selection == true) && (it->atom1->isSelected() || it->atom2->isSelected())))
+				if (!use_selection || (use_selection && (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, true, true,
@@ -1126,7 +1126,7 @@ namespace BALL
 			// first evaluate 1-4 non-bonded pairs 
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; ++it, i++)
 			{
-				if (use_selection == false || ((use_selection == true) && (it->atom1->isSelected() || it->atom2->isSelected())))
+				if (!use_selection || (use_selection && (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, true, false, 
@@ -1137,7 +1137,7 @@ namespace BALL
 			// evaluate remaining non-bonded pairs (also in the same vector) 
 			for (i = 0; it != non_bonded_.end(); ++it, i++)
 			{
-				if (use_selection == false || ((use_selection == true) && (   it->atom1->isSelected()
+				if (!use_selection || ((use_selection) && (   it->atom1->isSelected()
 																																	 || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
@@ -1152,8 +1152,8 @@ namespace BALL
 			// first evaluate 1-4 non-bonded pairs 
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; ++it, i++)
 			{
-				if (use_selection == false || ((use_selection == true)  && (   it->atom1->isSelected()
-																																		|| it->atom2->isSelected())))
+				if (!use_selection || (use_selection  &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, false, true,
@@ -1164,9 +1164,8 @@ namespace BALL
 			// evaluate remaining non-bonded pairs (also in the same vector) 
 			for (i = 0; it != non_bonded_.end(); ++it, i++)
 			{
-				if (use_selection == false
-						|| ((use_selection == true) && (   it->atom1->isSelected()
-																						|| it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, false, true,
@@ -1181,8 +1180,8 @@ namespace BALL
 			// first evaluate 1-4 non-bonded pairs 
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; ++it, i++)
 			{
-				if (use_selection == false || ((use_selection == true) && (it->atom1->isSelected()
-																																	 || it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, false, false,
@@ -1193,9 +1192,8 @@ namespace BALL
 			// evaluate remaining non-bonded pairs (also in the same vector) 
 			for (i = 0; it != non_bonded_.end(); ++it, i++)
 			{
-				if (use_selection == false
-						|| ((use_selection == true) && (   it->atom1->isSelected()
-																						|| it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticEnergy
 						(it, ENERGY_PARAMETERS, false, false,
@@ -1282,7 +1280,7 @@ namespace BALL
 
 		// calculate forces arising from 1-4 interaction pairs
 		// and remaining non-bonded interaction pairs
-		if ((use_periodic_boundary == true) && (use_dist_depend_dielectric_ == true))
+		if (use_periodic_boundary && use_dist_depend_dielectric_)
 		{
 			// periodic boundary is enabled; use a distance dependent dielectric constant 
 			// Calculate periods and half periods
@@ -1294,9 +1292,8 @@ namespace BALL
 			// first deal with 1-4 non-bonded pairs 
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; i++, ++it) 
 			{
-				if (use_selection == false 
-						|| ((use_selection == true) && (   it->atom1->isSelected()
-																						|| it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor_1_4, vdw_scaling_factor_1_4,
@@ -1307,9 +1304,8 @@ namespace BALL
 			// now deal with 'real' non-bonded pairs (in the same vector non_bonded_) 
 			for (i = 0; it != non_bonded_.end(); i++, ++it) 
 			{
-				if (use_selection == false 
-						|| ((use_selection == true) && (   it->atom1->isSelected()
-																						|| it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor, vdw_scaling_factor,
@@ -1328,8 +1324,8 @@ namespace BALL
 			// first deal with 1-4 non-bonded pairs
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; i++, ++it) 
 			{
-				if (use_selection == false || ((use_selection == true) && (   it->atom1->isSelected()
-																																	 || it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor_1_4, vdw_scaling_factor_1_4,
@@ -1340,8 +1336,8 @@ namespace BALL
 			// now deal with 'real' non-bonded pairs (in the same vector non_bonded_) 
 			for (i = 0; it != non_bonded_.end(); i++, ++it) 
 			{
-				if (use_selection == false || ((use_selection == true) && (it->atom1->isSelected() ||
-																																	 it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor, vdw_scaling_factor,
@@ -1349,15 +1345,15 @@ namespace BALL
 				}
 			}
 		}
-		else if (use_periodic_boundary == false && use_dist_depend_dielectric_ == true)
+		else if (!use_periodic_boundary && use_dist_depend_dielectric_)
 		{
 			// periodic boundary not enabled; use a distance dependent dielectric constant 
 
 			// first deal with 1-4 non-bonded pairs
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; i++, ++it) 
 			{
-				if (use_selection == false || ((use_selection == true) && (   it->atom1->isSelected()
-																																	 || it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor_1_4, vdw_scaling_factor_1_4,
@@ -1368,8 +1364,8 @@ namespace BALL
 			// now deal with 'real' non-bonded pairs (in the same vector non_bonded_)
 			for (i = 0; it != non_bonded_.end(); i++, ++it) 
 			{
-				if (use_selection == false || ((use_selection == true) && (   it->atom1->isSelected()
-																																	 || it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor, vdw_scaling_factor,
@@ -1384,8 +1380,8 @@ namespace BALL
 			// first deal with 1-4 non-bonded pairs
 			for (i = 0, it = non_bonded_.begin(); i < number_of_1_4_; i++, it++) 
 			{
-				if (use_selection == false || ((use_selection == true) && (   it->atom1->isSelected()
-																																	 || it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor_1_4, vdw_scaling_factor_1_4,
@@ -1396,8 +1392,8 @@ namespace BALL
 			// now deal with 'real' non-bonded pairs (in the same vector non_bonded_)
 			for (i = 0; it != non_bonded_.end(); i++, ++it) 
 			{
-				if (use_selection == false || ((use_selection == true) && (   it->atom1->isSelected() 
-																																	 || it->atom2->isSelected())))
+				if (!use_selection || (use_selection &&
+				    (it->atom1->isSelected() || it->atom2->isSelected())))
 				{
 					CHARMMcalculateVdWAndElectrostaticForce
 						(it, e_scaling_factor, vdw_scaling_factor,

--- a/source/MOLMEC/CHARMM/charmmStretch.C
+++ b/source/MOLMEC/CHARMM/charmmStretch.C
@@ -72,9 +72,9 @@ namespace BALL
 			for (bond_iterator = (*atom_it)->beginBond(); +bond_iterator; ++bond_iterator)
 			{
 				if (bond_iterator->getType() == Bond::TYPE__HYDROGEN) continue; // Skip H-bonds!
-				if (getForceField()->getUseSelection() == false ||
-				    (getForceField()->getUseSelection() == true &&
-				    ((*bond_iterator).getFirstAtom()->isSelected() && (*bond_iterator).getSecondAtom()->isSelected())))
+				if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection()
+				    && (*bond_iterator).getFirstAtom()->isSelected()
+				    && (*bond_iterator).getSecondAtom()->isSelected()))
 				{
 					if ((*bond_iterator).getPartner(**atom_it) == (*bond_iterator).getSecondAtom())
 					{
@@ -99,7 +99,7 @@ namespace BALL
 		{
 			bool result = stretch_parameters_.extractSection(getForceField()->getParameters(), "QuadraticBondStretch");
 
-			if (result == false) 
+			if (!result)
 			{
 				Log.error() << "cannot find section QuadraticBondStretch" << endl;
 				return false;
@@ -120,9 +120,9 @@ namespace BALL
 					
 					Bond&	bond = const_cast<Bond&>(*it);
 					if (bond.getType() == Bond::TYPE__HYDROGEN) continue; // Skip H-bonds!
-					if (getForceField()->getUseSelection() == false ||
-					   (getForceField()->getUseSelection() == true && 
-					   (bond.getFirstAtom()->isSelected() && bond.getSecondAtom()->isSelected())))
+					if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection()
+					    && bond.getFirstAtom()->isSelected()
+					    && bond.getSecondAtom()->isSelected()))
 					{
 
 						Atom::Type atom_type_A = bond.getFirstAtom()->getType();

--- a/source/MOLMEC/CHARMM/charmmTorsion.C
+++ b/source/MOLMEC/CHARMM/charmmTorsion.C
@@ -93,7 +93,7 @@ namespace BALL
 			// extract the torsion parameters
 			result = torsion_parameters_.extractSection(getForceField()->getParameters(), "Torsions");
 
-			if (result == false) 
+			if (!result)
 			{
 				Log.error() << "cannot find section Torsions" << endl;
 				return false;
@@ -104,7 +104,7 @@ namespace BALL
 			if (getForceField()->getParameters().getParameterFile().hasSection("ResidueTorsions"))
 			{
 				result = residue_torsions_.extractSection(getForceField()->getParameters(), "ResidueTorsions");
-				if (result == false)
+				if (!result)
 				{
 					Log.error() << "CharmmTorsion::setup: cannot parse section Torsions" << endl;
 					return false;
@@ -168,9 +168,9 @@ namespace BALL
 										a4 = const_cast<Atom*>(it3->getFirstAtom());
 									}
 
-									if (getForceField()->getUseSelection() == false ||
-											(getForceField()->getUseSelection() == true &&
-											 (a1->isSelected() && a2->isSelected() && a3->isSelected() && a4->isSelected())))
+									if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection()
+									    && a1->isSelected() && a2->isSelected()
+									    && a3->isSelected() && a4->isSelected()))
 									{
 										// if we use ResidueTorsions (i.e. a list of torsions for each
 										// residue is specified in the parameter file), we have to check
@@ -348,9 +348,9 @@ namespace BALL
 
 		for ( ; it != torsion_.end(); it++) 
 		{
-			if ( getForceField()->getUseSelection() == false ||
-					( getForceField()->getUseSelection() == true &&
-					(it->atom1->isSelected() || it->atom2->isSelected() || it->atom3->isSelected() || it->atom4->isSelected())))
+			if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection() &&
+			    (   it->atom1->isSelected() || it->atom2->isSelected()
+			     || it->atom3->isSelected() || it->atom4->isSelected())))
 			{
 				a21 = it->atom1->getPosition() - it->atom2->getPosition();
 				a23 = it->atom3->getPosition() - it->atom2->getPosition();
@@ -404,10 +404,9 @@ namespace BALL
 
 		for (; it != torsion_.end(); it++) 
 		{
-			if (getForceField()->getUseSelection() == false ||
- 					(getForceField()->getUseSelection() == true &&
-					(it->atom1->isSelected() || it->atom2->isSelected() 
-					 || it->atom3->isSelected() || it->atom4->isSelected())))
+			if (!getForceField()->getUseSelection() || (getForceField()->getUseSelection() &&
+			    (   it->atom1->isSelected() || it->atom2->isSelected()
+			     || it->atom3->isSelected() || it->atom4->isSelected())))
 			{
 				ab = it->atom1->getPosition() - it->atom2->getPosition();
 				double length_ab = ab.getLength();
@@ -459,7 +458,7 @@ namespace BALL
 						Vector3 dEdu = - (float)(dEdphi / (length_u2 * cb.getLength())) * (u % cb);
 	
 
-						if (getForceField()->getUseSelection() == false)
+						if (!getForceField()->getUseSelection())
 						{
 							it->atom1->getForce() += dEdt % cb;
 							it->atom2->getForce() += ca % dEdt + dEdu % dc;

--- a/source/MOLMEC/COMMON/bendComponent.C
+++ b/source/MOLMEC/COMMON/bendComponent.C
@@ -38,7 +38,7 @@ namespace BALL
 			const Atom* atom1 = bend_it->atom1;
 			const Atom* atom2 = bend_it->atom2;
 			const Atom* atom3 = bend_it->atom3;
-			if (use_selection == false ||
+			if (!use_selection ||
 					(   atom1->isSelected()
 					 || atom2->isSelected()
 					 || atom3->isSelected()))
@@ -90,7 +90,7 @@ namespace BALL
 			Atom* atom2 = bend_[i].atom2;
 			Atom* atom3 = bend_[i].atom3;
 
-			if ((use_selection == false)
+			if (!use_selection
 					|| atom1->isSelected()
 					|| atom2->isSelected()
 					|| atom3->isSelected())
@@ -155,7 +155,7 @@ namespace BALL
 				n1 *= factor * inverse_length_v1;
 				n2 *= factor * inverse_length_v2;
 
-				if (use_selection == false)
+				if (!use_selection)
 				{
 					atom1->getForce() -= n1;
 					atom2->getForce() += n1;

--- a/source/MOLMEC/COMMON/snapShotManager.C
+++ b/source/MOLMEC/COMMON/snapShotManager.C
@@ -244,7 +244,7 @@ namespace BALL
 
 		atom_it = selected_atoms.begin();
 
-		if (force_field_ptr_->periodic_boundary.isEnabled() == true)
+		if (force_field_ptr_->periodic_boundary.isEnabled())
 		{
 			float molecule_mass = 0;
 			float mass;

--- a/source/MOLMEC/COMMON/support.C
+++ b/source/MOLMEC/COMMON/support.C
@@ -405,7 +405,7 @@ Log.error() << "calculateNonBondedAtomPairs time: " << String(t.getClockTime()) 
 					new_molecule = atom_it->getMolecule();
 					if (new_molecule != old_molecule) 
 					{
-						if (add == true) 
+						if (add)
 						{
 							if ((atom_counter > 0) && (mass != 0)) 
 							{
@@ -463,7 +463,7 @@ Log.error() << "calculateNonBondedAtomPairs time: " << String(t.getClockTime()) 
 					}
 				}	
 
-				if (add == true) 
+				if (add)
 				{
 					if ((atom_counter > 0) && (mass != 0)) 
 					{
@@ -599,7 +599,7 @@ Log.error() << "calculateNonBondedAtomPairs time: " << String(t.getClockTime()) 
 					}
 
 				}
-				if (keep == false)
+				if (!keep)
 				{
 					delete_set.insert(&*mol_it);
 				}

--- a/source/MOLMEC/MDSIMULATION/canonicalMD.C
+++ b/source/MOLMEC/MDSIMULATION/canonicalMD.C
@@ -200,7 +200,7 @@ namespace BALL
 		vector <Atom*>::iterator atom_it;
 		vector <AuxFactors>::iterator factor_it;
 
-		if (restart == false)
+		if (!restart)
 		{
 			// reset the current number of iteration and the simulation time to
 			// the values given in the options
@@ -239,7 +239,7 @@ namespace BALL
 
 		// If the simulation runs with periodic boundary conditions, update the
 		// position of molecules
-		if (force_field_ptr_->periodic_boundary.isEnabled() == true)
+		if (force_field_ptr_->periodic_boundary.isEnabled())
 		{
 			force_field_ptr_->periodic_boundary.updateMolecules();
 		}
@@ -261,7 +261,7 @@ namespace BALL
 
 			// If the simulation runs with periodic boundary conditions, update the
 			// list and position of molecules
-			if (force_field_ptr_->periodic_boundary.isEnabled() == true)
+			if (force_field_ptr_->periodic_boundary.isEnabled())
 			{
 				force_field_ptr_->periodic_boundary.updateMolecules();
 			}

--- a/source/MOLMEC/MDSIMULATION/microCanonicalMD.C
+++ b/source/MOLMEC/MDSIMULATION/microCanonicalMD.C
@@ -75,7 +75,7 @@ namespace BALL
 	{
 		// First check whether the force field is valid. If not, then it is useless
 		// to do anything here.
-		if (my_force_field.isValid() == false)
+		if (!my_force_field.isValid())
 		{
 			// The setup has failed for some reason. Output an error message.
 			Log.error() << "MicroCanonicalMD::setup: setup failed because the force field was not valid!" << std::endl;
@@ -87,7 +87,7 @@ namespace BALL
 		// call the base class setup method
 		valid_ = MolecularDynamics::setup(my_force_field, ssm, my_options);
 
-		if (valid_ == false)
+		if (!valid_)
 			return false;
 
 		// call the specific Setup
@@ -163,7 +163,7 @@ namespace BALL
 		Size force_update_freq = 0;
 		Size iteration = 0;
 
-    if (restart == false)
+    if (!restart)
     {
       // reset the current number of iteration and the simulation time  to the values given
       // in the options 
@@ -202,7 +202,7 @@ namespace BALL
 
 		// If the simulation runs with periodic boundary conditions, update the
 		// list and position of molecules
-		if (force_field_ptr_->periodic_boundary.isEnabled() == true)
+		if (force_field_ptr_->periodic_boundary.isEnabled())
 		{
 			force_field_ptr_->periodic_boundary.updateMolecules();
 		}
@@ -228,7 +228,7 @@ namespace BALL
 
 			// If the simulation runs with periodic boundary conditions, update the
 			// list and position of molecules
-			if (force_field_ptr_->periodic_boundary.isEnabled() == true)
+			if (force_field_ptr_->periodic_boundary.isEnabled())
 			{
 				force_field_ptr_->periodic_boundary.updateMolecules();
 			}

--- a/source/MOLMEC/MDSIMULATION/molecularDynamics.C
+++ b/source/MOLMEC/MDSIMULATION/molecularDynamics.C
@@ -174,7 +174,7 @@ namespace BALL
 	{
 		// First check whether the force field is valid. If not, then it is useless
 		// to do anything here.
-		if (force_field.isValid() == false)
+		if (!force_field.isValid())
 		{
 			// The setup has failed for some reason. Output an error message.
 			Log.error() << "Setup of instance of class 'MolecularDynamics' has failed." << std::endl;
@@ -498,7 +498,7 @@ namespace BALL
 		// gravity, otherwise we iterate directly over the individual atoms of the system 
 	  atom_it = atom_vector_.begin();
 
-		if (force_field_ptr_->periodic_boundary.isEnabled() == true)
+		if (force_field_ptr_->periodic_boundary.isEnabled())
 		{
 			double molecule_mass = 0;
 			float mass;

--- a/source/MOLMEC/MINIMIZATION/lineSearch.C
+++ b/source/MOLMEC/MINIMIZATION/lineSearch.C
@@ -496,7 +496,7 @@ namespace BALL
 		double new_stp;
 		
 		// Compute whether we have directional derivatives of opposite sign.
-		bool opp_sign =  (g*(g_a/fabs(g_a)) < 0.) ? true : false;
+		bool opp_sign =  g*(g_a/fabs(g_a)) < 0.;
 		
 		// Check the four possible cases.
 		if (f > f_a)

--- a/source/MOLMEC/MINIMIZATION/strangLBFGS.C
+++ b/source/MOLMEC/MINIMIZATION/strangLBFGS.C
@@ -750,7 +750,7 @@ namespace BALL
 			while ((!result) && (iter < 12))
 			{
 				result = line_search_.minimize(step_);
-				if (result == false)
+				if (!result)
 				{
 					for(Size i = 0; i <  number_of_atoms_; ++i)
 					{

--- a/source/NMR/EFShiftProcessor.C
+++ b/source/NMR/EFShiftProcessor.C
@@ -152,7 +152,7 @@ namespace BALL
 		}
 
 		// Built the charge hash map.
-		if ((result == true) && parameter_section.hasVariable("charge"))
+		if (result && parameter_section.hasVariable("charge"))
 		{
 			Position charge_column = parameter_section.getColumnIndex("charge");
 			for (Position i = 0; i < parameter_section.getNumberOfKeys(); i++)

--- a/source/NMR/createSpectrumProcessor.C
+++ b/source/NMR/createSpectrumProcessor.C
@@ -127,7 +127,7 @@ namespace BALL
 				if ((!(ignore_atoms_.has(atom->getFullName())
 							 || ignore_atoms_.has("*:" + atom->getName()))
 						 || !use_ignore_table_)
-						&& (expression_(*atom) == true)
+						&& expression_(*atom)
 						&& (shift != 0.0))
 				{
 					Peak1D peak;
@@ -141,7 +141,7 @@ namespace BALL
 		}
 		
 
-		if (use_averaging_ == true)
+		if (use_averaging_)
 		{
 			// average the shifts of chemically equivalent nuclei
 			// in a residue

--- a/source/NMR/empiricalHSShiftProcessor.C
+++ b/source/NMR/empiricalHSShiftProcessor.C
@@ -1507,20 +1507,15 @@ namespace BALL
 	// Returns true, if the property type is alphanumeric/discrete.
 	bool EmpiricalHSShiftProcessor::PropertiesForShift_::isDiscrete(String property)
 	{
-		if( property.hasSubstring("PSI") || property.hasSubstring("PHI") || 
-				property.hasSubstring("HA2L") || property.hasSubstring("HA1L") || 
-				property.hasSubstring("HNL") || property.hasSubstring("OHL")|| property.hasSubstring("CHI") )
-			return false;
-		else
-			return true;
+		return !(property.hasSubstring("PSI")  || property.hasSubstring("PHI")
+		      || property.hasSubstring("HA2L") || property.hasSubstring("HA1L")
+		      || property.hasSubstring("HNL")  || property.hasSubstring("OHL")
+		      || property.hasSubstring("CHI"));
 	}
 	
 	bool EmpiricalHSShiftProcessor::PropertiesForShift_::isMixed(String property)
 	{
-		if(property.hasSubstring("CHI") || property.hasSubstring("CHI2"))
-			return true;
-		else
-			return false;
+		return property.hasSubstring("CHI") || property.hasSubstring("CHI2");
 	}
 
 	

--- a/source/NMR/experiment.C
+++ b/source/NMR/experiment.C
@@ -34,7 +34,7 @@ namespace BALL
 	Processor::Result SimpleExperiment1D::operator () (Composite& composite)
 	{
 		Atom* atom_ptr = dynamic_cast<Atom*>(&composite);
-		if ((atom_ptr != 0) && (expression_(*atom_ptr) == true))
+		if ((atom_ptr != 0) && expression_(*atom_ptr))
 		{
 			// create a new peak at the end of the list
 			peak_list_.push_back(default_peak_);

--- a/source/QSAR/aromaticityProcessor.C
+++ b/source/QSAR/aromaticityProcessor.C
@@ -433,14 +433,7 @@ namespace BALL
 			}
 		}
 
-		if (destab < 2)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return destab < 2;
 	}
 
 	bool AromaticityProcessor::simpleCanBeAromaticWeaker_(const HashSet<Atom*>& ring)
@@ -485,14 +478,7 @@ namespace BALL
 				}
 			}
 		}
-		if (destab < 2)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return destab < 2;
 	}
 
 	void AromaticityProcessor::aromatize(const vector<vector<Atom*> >& sssr_orig, AtomContainer& ac)

--- a/source/QSAR/nBModel.C
+++ b/source/QSAR/nBModel.C
@@ -190,8 +190,7 @@ namespace BALL
 				sel_features = data->getNoDescriptors();
 			}
 			
-			if (probabilities_.size() > 0 && (unsigned int)min_max_.cols() == sel_features) return true; 
-			return false;
+			return probabilities_.size() > 0 && (unsigned int)min_max_.cols() == sel_features;
 		}
 
 

--- a/source/QSAR/snBModel.C
+++ b/source/QSAR/snBModel.C
@@ -188,8 +188,7 @@ namespace BALL
 			{
 				sel_features = data->getNoDescriptors();
 			}
-			if (!mean_.empty() && (unsigned int)mean_[0].cols() == sel_features) return true; 
-			return false;
+			return !mean_.empty() && (unsigned int)mean_[0].cols() == sel_features;
 		}
 
 

--- a/source/SCORING/COMPONENTS/CHPI.C
+++ b/source/SCORING/COMPONENTS/CHPI.C
@@ -624,7 +624,7 @@ namespace BALL
 								Log.info() << "Score: " << e << std::endl;
 							}
 
-							if (write_interactions_file_ == true)
+							if (write_interactions_file_)
 							{
 								Atom* atom_ptr_H = new Atom();
 								atom_ptr_H->setElement(PTE[Element::Fe]);
@@ -675,7 +675,7 @@ namespace BALL
 				Log.info() << "CHPI: energy is " << score_ << endl;
 			}
 
-			if (write_interactions_file_ == true)
+			if (write_interactions_file_)
 			{
 				HINFile interactions_file("CHPI_interactions.hin", std::ios::out);
 				interactions_file << interactions_molecule;

--- a/source/SCORING/COMPONENTS/CHPISlick.C
+++ b/source/SCORING/COMPONENTS/CHPISlick.C
@@ -597,7 +597,7 @@ namespace BALL
 							Log.info() << "Score: " << e << std::endl;
 						}
 
-						if (write_interactions_file_ == true)
+						if (write_interactions_file_)
 						{
 							Atom* atom_ptr_H = new Atom();
 							atom_ptr_H->setElement(PTE[Element::Fe]);
@@ -648,7 +648,7 @@ namespace BALL
 			Log.info() << "CHPISlick: energy is " << score_ << endl;
 		}
 
-		if (write_interactions_file_ == true)
+		if (write_interactions_file_)
 		{
 			HINFile interactions_file("CHPISlick_interactions.hin", std::ios::out);
 			interactions_file << interactions_molecule;

--- a/source/SCORING/COMPONENTS/PLP.C
+++ b/source/SCORING/COMPONENTS/PLP.C
@@ -57,18 +57,12 @@ bool PLP::isSp3(const Atom* at)
 
 	if (at->getElement().getName() == "Oxygen")
 	{
-		if (at->countBonds() == 1)
-			return false;
-		else
-			return true;
+		return at->countBonds() != 1;
 	}
 
 	if (at->getElement().getName() == "Carbon")
 	{
-		if (at->countBonds() == 4)
-			return true;
-
-		return false;
+		return at->countBonds() == 4;
 	}
 
 	return true;

--- a/source/SCORING/COMPONENTS/buriedPolar.C
+++ b/source/SCORING/COMPONENTS/buriedPolar.C
@@ -131,13 +131,8 @@ Size BuriedPolar::getType(Atom* atom)
 
 bool BuriedPolar::isBackboneAtom(const Atom* atom)
 {
-	if (atom->getName() == "O" || atom->getName() == "N" || atom->getName() == "H"
-		|| atom->getName() == "C")
-	{
-		return true;
-	}
-
-	return false;
+	return atom->getName() == "O" || atom->getName() == "N"
+	    || atom->getName() == "H" || atom->getName() == "C";
 }
 
 

--- a/source/SCORING/COMPONENTS/lipophilic.C
+++ b/source/SCORING/COMPONENTS/lipophilic.C
@@ -232,7 +232,7 @@ double Lipophilic::updateScore()
 					<< ", R2 " << R2 << ")" << endl;
 			}
 
-			if (write_interactions_file_ == true)
+			if (write_interactions_file_)
 			{
 				Atom* atom_ptr_L1 = new Atom();
 				atom_ptr_L1->setElement(atom1->getElement());
@@ -256,7 +256,7 @@ double Lipophilic::updateScore()
 		}
 	}
 
-	if (write_interactions_file_ == true)
+	if (write_interactions_file_)
 	{
 		HINFile debug_file("LIPO_debug.hin", std::ios::out);
 		debug_file << interactions_molecule;

--- a/source/SCORING/COMPONENTS/nonpolarSolvation.C
+++ b/source/SCORING/COMPONENTS/nonpolarSolvation.C
@@ -213,7 +213,7 @@ namespace BALL
 					NonpolarSolvation::Default::NONPOLAR_OVERWRITE_RADII);
 
 		String tmp;
-		if (overwrite_radii == true)
+		if (overwrite_radii)
 		{
 			String filename
 				= options->setDefault(NonpolarSolvation::Option::NONPOLAR_RADIUS_RULES,
@@ -234,7 +234,7 @@ namespace BALL
 
 		System protein_system;
 		Molecule* protein = new Molecule(*(getScoringFunction()->getReceptor()), true);
-		if (overwrite_radii == true)
+		if (overwrite_radii)
 		{
 			protein->apply(radius_rules);
 		}
@@ -263,7 +263,7 @@ namespace BALL
 
 		System ligand_system;
 		Molecule* ligand = new Molecule(*(getScoringFunction()->getLigand()), true);
-		if (overwrite_radii == true)
+		if (overwrite_radii)
 		{
 			ligand->apply(radius_rules);
 		}

--- a/source/SCORING/COMPONENTS/polarSolvation.C
+++ b/source/SCORING/COMPONENTS/polarSolvation.C
@@ -149,7 +149,7 @@ namespace BALL
 			= options->setDefaultBool(PolarSolvation::Option::POLAR_GB,
 					PolarSolvation::Default::POLAR_GB);
 
-		if (use_gb_ == true)
+		if (use_gb_)
 		{
 			gbm_.setScalingFactorFile((*options)[PolarSolvation::Option::GB_SCALING_FILE]);
 		}
@@ -241,7 +241,7 @@ namespace BALL
 		desolv_protein_ = Molecule(*getScoringFunction()->getReceptor(), true);
 		desolv_ligand_ = Molecule(*getScoringFunction()->getLigand(), true);
 
-		if (unite_atoms_ == true)
+		if (unite_atoms_)
 		{
 			uniteAtoms_(desolv_protein_);
 			uniteAtoms_(desolv_ligand_);
@@ -349,12 +349,12 @@ namespace BALL
 						bb_proc.getUpper());
 
 				result = computeEnergyDifference_(system, dG_reac_system);
-				if (result == false) return false;
+				if (!result) return false;
 
 				system.clear();
 				system.insert(*((Molecule*)(desolv_protein_.create(true))));
 				result = computeEnergyDifference_(system, dG_reac_protein);
-				if (result == false) return false;
+				if (!result) return false;
 
 			}
 
@@ -377,7 +377,7 @@ namespace BALL
 					// dG_reac_ligand should still be zero (see definition above)
 
 					result = computeEnergyDifference_(system, tmp_energy);
-					if (result == false) return false;
+					if (!result) return false;
 					dG_reac_ligand += tmp_energy;
 
 					// ????? hardcoded
@@ -394,7 +394,7 @@ namespace BALL
 						offset_vector = permuteComponentSigns_(Vector3(offset), i);
 						fdpb_.options.setVector(FDPB::Option::OFFSET, offset_vector);
 						result = computeEnergyDifference_(system, tmp_energy);
-						if (result == false) return false;
+						if (!result) return false;
 						dG_reac_ligand += tmp_energy;
 						if (tmp_energy < minimal_energy) minimal_energy = tmp_energy;
 						if (tmp_energy > maximal_energy) maximal_energy = tmp_energy;
@@ -420,7 +420,7 @@ namespace BALL
 			else
 			{
 				result = computeEnergyDifference_(system, dG_reac_ligand);
-				if (result == false) return false;
+				if (!result) return false;
 			}
 
 			score_ = dG_reac_system - dG_reac_protein - dG_reac_ligand;
@@ -447,7 +447,7 @@ namespace BALL
 						bb_proc.getUpper());
 
 				result = computeFullCycle_(system, tmp_protein, tmp_ligand, tmp_energy);
-				if (result == false) return false;
+				if (!result) return false;
 
 				score_ = tmp_energy;
 
@@ -515,7 +515,7 @@ namespace BALL
 
 						result = computeFullCycle_(cut_system, cut_protein, cut_ligand,
 								tmp_energy);
-						if (result == false) return false;
+						if (!result) return false;
 						score_ = tmp_energy;
 					}
 					else
@@ -530,7 +530,7 @@ namespace BALL
 
 							result = computeFullCycle_(cut_system, cut_protein,
 									cut_ligand, tmp_energy);
-							if (result == false) return false;
+							if (!result) return false;
 							score_ += tmp_energy;
 
 							// energy minimium
@@ -544,7 +544,7 @@ namespace BALL
 								fdpb_.options.setVector(FDPB::Option::OFFSET, offset_vector);
 								result = computeFullCycle_(cut_system, cut_protein,
 										cut_ligand, tmp_energy);
-								if (result == false) return false;
+								if (!result) return false;
 								if (tmp_energy < minimal_energy) minimal_energy = tmp_energy;
 								if (tmp_energy > maximal_energy) maximal_energy = tmp_energy;
 								score_ += tmp_energy;
@@ -620,7 +620,7 @@ namespace BALL
 	{
 		float dG;
 
-		if (use_gb_ == true)
+		if (use_gb_)
 		{
 			gbm_.setup(system);
 
@@ -670,7 +670,7 @@ namespace BALL
 	bool PolarSolvation::computeESEnergy_(System& system, float& energy)
 
 	{
-		if (use_gb_ == true)
+		if (use_gb_)
 		{
 			gbm_.setup(system);
 			energy = gbm_.calculateEnergy();
@@ -710,7 +710,7 @@ namespace BALL
 			if (charge != 0.0f)
 			{
 				float potential;
-				if (use_gb_ == true)
+				if (use_gb_)
 				{
 					potential = p_hash[&*atom_it];
 				}
@@ -774,7 +774,7 @@ namespace BALL
 		// Protein radii and charges are still untouched, so we can instantly
 		// calculate the ES energy
 		bool result = computeESEnergy_(system, dGes_A);
-		if (result == false) return false;
+		if (!result) return false;
 		if (verbosity_ > 1) Log.info() << "dGes_A = " << dGes_A << endl;
 
 		// 2. Calculate the ES energy of the ligand
@@ -804,7 +804,7 @@ namespace BALL
 
 		// Now compute the ES energy
 		result = computeESEnergy_(system, dGes_B);
-		if (result == false) return false;
+		if (!result) return false;
 		if (verbosity_ > 1) Log.info() << "dGes_B = " << dGes_B << endl;
 
 		// 3. Calculate the ES energy of the protein in presence of a cavity
@@ -836,14 +836,14 @@ namespace BALL
 
 		// Comoute the electrostatic energy
 		result = computeESEnergy_(system, dGes_A_cav_B);
-		if (result == false) return false;
+		if (!result) return false;
 		if (verbosity_ > 1) Log.info() << "dGes_A_cav_B = " << dGes_A_cav_B << endl;
 
 		// 5. (a) Compute the ES interaction energies of the complex partners.
 		// This is done by computing the energy of the ligand in the potential
 		// of the protein and vice versa
 		HashMap<const Atom*, float> p_hash;
-		if (use_gb_ == true)
+		if (use_gb_)
 		{
 			gbm_.calculatePotential(p_hash);
 		}
@@ -879,13 +879,13 @@ namespace BALL
 		}
 		// ligand radii should be correct.
 		result = computeESEnergy_(system, dGes_B_cav_A);
-		if (result == false) return false;
+		if (!result) return false;
 		if (verbosity_ > 1) Log.info() << "dGes_B_cav_A = " << dGes_B_cav_A << endl;
 
 		// 5. (a) Compute the ES interaction energies of the complex partners.
 		// This is done by computing the energy of the ligand in the potential
 		// of the protein and vice versa
-		if (use_gb_ == true)
+		if (use_gb_)
 		{
 			gbm_.calculatePotential(p_hash);
 		}

--- a/source/SCORING/COMPONENTS/polarity.C
+++ b/source/SCORING/COMPONENTS/polarity.C
@@ -110,12 +110,9 @@ bool Polarity::isPolar_(const Atom* atom)
 	if (fabs(atom->getCharge()) < POL_ES_THRESHOLD) return false;
 
 	int type = getType_(atom);
-	if ( (type == FresnoTypes::POLAR) || (type == FresnoTypes::HBOND_ACCEPTOR)
-		|| (type == FresnoTypes::HBOND_DONOR) || (type == FresnoTypes::HBOND_ACCEPTOR_DONOR) || (type == FresnoTypes::HBOND_HYDROGEN) )
-	{
-		return true;
-	}
-	else return false;
+	return (type == FresnoTypes::POLAR)       || (type == FresnoTypes::HBOND_ACCEPTOR)
+	    || (type == FresnoTypes::HBOND_DONOR) || (type == FresnoTypes::HBOND_ACCEPTOR_DONOR)
+	    || (type == FresnoTypes::HBOND_HYDROGEN);
 }
 
 
@@ -125,23 +122,14 @@ bool Polarity::isLipophilic_(const Atom* atom)
 	if (fabs(atom->getCharge()) > LIP_ES_THRESHOLD) return false;
 
 	int type = getType_(atom);
-	if (type == FresnoTypes::LIPOPHILIC)
-	{
-		return true;
-	}
-	else return false;
+	return type == FresnoTypes::LIPOPHILIC;
 }
 
 
 bool Polarity::isBackboneAtom_(const Atom* atom)
 {
-	if (atom->getName() == "O" || atom->getName() == "N" || atom->getName() == "H"
-		|| atom->getName() == "C" /*|| atom->getName() == "CA"*/)
-	{
-		return true;
-	}
-
-	return false;
+	return atom->getName() == "O" || atom->getName() == "N"
+	    || atom->getName() == "H" || atom->getName() == "C";
 }
 
 

--- a/source/SCORING/COMPONENTS/rotationalEntropy.C
+++ b/source/SCORING/COMPONENTS/rotationalEntropy.C
@@ -21,7 +21,7 @@ RotationalEntropy::RotationalEntropy(ScoringFunction& sf)
 
 void RotationalEntropy::setLigandIntraMolecular(bool b)
 {
-	if (b == true)
+	if (b)
 	{
 		std::cout<<"RotationalEntropy ScoringComponent can not be used to compute ligand conformation score !"<<std::endl;
 	}

--- a/source/SCORING/COMPONENTS/vanDerWaalsSlick.C
+++ b/source/SCORING/COMPONENTS/vanDerWaalsSlick.C
@@ -186,12 +186,12 @@ namespace BALL
 
 		// Read the parameters for the VDW calculation
 		bool result = lennard_jones_.extractSection(parameters, "LennardJones");
-		if (result == false)
+		if (!result)
 		{
 			return(false);
 		}
 		result = hydrogen_bond_.extractSection(parameters, "HydrogenBonds");
-		if (result == false)
+		if (!result)
 		{
 			return(false);
 		}

--- a/source/SOLVATION/claverieParameter.C
+++ b/source/SOLVATION/claverieParameter.C
@@ -53,14 +53,7 @@ namespace BALL
 
 	bool ClaverieParameter::hasParameters(Atom::Type solvent_type, Atom::Type solute_type) const
 	{
-		if (indices_.has(solvent_type) && indices_.has(solute_type))
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return indices_.has(solvent_type) && indices_.has(solute_type);
 	}
 
 

--- a/source/SOLVATION/electrostaticPotentialCalculator.C
+++ b/source/SOLVATION/electrostaticPotentialCalculator.C
@@ -59,7 +59,7 @@ namespace BALL
 		float length;
 		static float eps=78.;
 		
-		if (options.getBool(Option::LOCALITY)==true)
+		if (options.getBool(Option::LOCALITY))
 		{
 			AtomIterator atIt;
 

--- a/source/SOLVATION/generalizedBornCase.C
+++ b/source/SOLVATION/generalizedBornCase.C
@@ -226,7 +226,7 @@ namespace BALL
 		if (scaling_factors_.size() == 0)
 		{
 			// Read scaling factors from standard INIfile
-			if (readScalingFactors(scaling_factor_filename_) == false)
+			if (!readScalingFactors(scaling_factor_filename_))
 			{
 				return(false);
 			}

--- a/source/SOLVATION/pair6_12InteractionEnergyProcessor.C
+++ b/source/SOLVATION/pair6_12InteractionEnergyProcessor.C
@@ -184,7 +184,7 @@ namespace BALL
 		// the file containing the rdf descriptions
 		Path path;
 		String rdf_filename;
-		if (use_rdf == true)
+		if (use_rdf)
 		{
 			rdf_filename = path.find(options.get(Option::RDF_FILENAME));
 			if (rdf_filename == "")

--- a/source/STRUCTURE/RDFParameter.C
+++ b/source/STRUCTURE/RDFParameter.C
@@ -59,14 +59,7 @@ namespace BALL
 	{
 		if (rdf_indices_.has(solvent_atom_type))
 		{
-			if (rdf_indices_[solvent_atom_type].has(solute_atom_type))
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			return rdf_indices_[solvent_atom_type].has(solute_atom_type);
 		}
 		else 
 		{

--- a/source/STRUCTURE/RSEdge.C
+++ b/source/STRUCTURE/RSEdge.C
@@ -228,7 +228,7 @@ namespace BALL
 	TVector3<double> RSEdge::getIntersectionPoint(Position i) const
 		throw(Exception::GeneralException)
 	{
-		if (singular_ == false)
+		if (!singular_)
 		{
 			throw Exception::GeneralException(__FILE__, __LINE__);
 		}

--- a/source/STRUCTURE/RSVertex.C
+++ b/source/STRUCTURE/RSVertex.C
@@ -86,14 +86,14 @@ namespace BALL
 		HashSet<RSEdge*>::ConstIterator e;
 		for (e = edges_.begin(); e != edges_.end(); e++)
 		{
-			if (rsvertex.edges_.has(*e) == false)
+			if (!rsvertex.edges_.has(*e))
 			{
 				return false;
 			}
 		}
 		for (e = rsvertex.edges_.begin(); e != rsvertex.edges_.end(); e++)
 		{
-			if (edges_.has(*e) == false)
+			if (!edges_.has(*e))
 			{
 				return false;
 			}
@@ -101,14 +101,14 @@ namespace BALL
 		HashSet<RSFace*>::ConstIterator f;
 		for (f = faces_.begin(); f != faces_.end(); f++)
 		{
-			if (rsvertex.faces_.has(*f) == false)
+			if (!rsvertex.faces_.has(*f))
 			{
 				return false;
 			}
 		}
 		for (f = rsvertex.faces_.begin(); f != rsvertex.faces_.end(); f++)
 		{
-			if (faces_.has(*f) == false)
+			if (!faces_.has(*f))
 			{
 				return false;
 			}

--- a/source/STRUCTURE/SESFace.C
+++ b/source/STRUCTURE/SESFace.C
@@ -161,7 +161,7 @@ namespace BALL
 		{
 			return;
 		}
-		if (singular == false)
+		if (!singular)
 		{
 			normalizeNonSingularToricFace_();
 		}

--- a/source/STRUCTURE/assignBondOrderProcessor.C
+++ b/source/STRUCTURE/assignBondOrderProcessor.C
@@ -286,12 +286,12 @@ namespace BALL
 		if (   (options.get(Option::ALGORITHM) == Algorithm::FPT)
 				&& (  // (options.getBool(Option::USE_FINE_PENALTY) == true) ||
 						   (options.getReal(Option::BOND_LENGTH_WEIGHTING) > 0.)
-						|| (options.getBool(Option::ADD_HYDROGENS) == true)
-						|| (options.getBool(Option::COMPUTE_ALSO_CONNECTIVITY) == true)
-						|| (options.getBool(Option::OVERWRITE_SELECTED_BONDS)  == true)
-						|| (options.getBool(Option::OVERWRITE_SINGLE_BOND_ORDERS) == false)
-						|| (options.getBool(Option::OVERWRITE_DOUBLE_BOND_ORDERS) == false)
-						|| (options.getBool(Option::OVERWRITE_TRIPLE_BOND_ORDERS) == false) )
+						||  options.getBool(Option::ADD_HYDROGENS)
+						||  options.getBool(Option::COMPUTE_ALSO_CONNECTIVITY)
+						||  options.getBool(Option::OVERWRITE_SELECTED_BONDS)
+						|| !options.getBool(Option::OVERWRITE_SINGLE_BOND_ORDERS)
+						|| !options.getBool(Option::OVERWRITE_DOUBLE_BOND_ORDERS)
+						|| !options.getBool(Option::OVERWRITE_TRIPLE_BOND_ORDERS))
 			 )
 		{
 			Log.error() << __FILE__ << " " << __LINE__

--- a/source/STRUCTURE/binaryFingerprintMethods.C
+++ b/source/STRUCTURE/binaryFingerprintMethods.C
@@ -1567,7 +1567,7 @@ bool BinaryFingerprintMethods::connectedComponents(const vector<unsigned int>& s
 	ccs.clear();
 	nn_data.clear();
 	
-	if (checkInputData(selection) == false)
+	if (!checkInputData(selection))
 	{
 		return false;
 	}
@@ -1909,7 +1909,7 @@ bool BinaryFingerprintMethods::calculateSelectionMedoid(const vector<unsigned in
 	medoid_index = selection.size() + 1;
 	LongSize n_molecules = selection.size();
 	
-	if (checkInputData(selection) == false)
+	if (!checkInputData(selection))
 	{
 		return false;
 	}
@@ -1974,7 +1974,7 @@ bool BinaryFingerprintMethods::averageLinkageClustering(const vector<unsigned in
 		return true;
 	}
 	
-	if (checkInputData(selection) == false)
+	if (!checkInputData(selection))
 	{
 		return false;
 	}

--- a/source/STRUCTURE/disulfidBondProcessor.C
+++ b/source/STRUCTURE/disulfidBondProcessor.C
@@ -62,8 +62,8 @@ namespace BALL
 			// store for us
 			if ((bond_it->getFirstAtom()->getElement() == PTE[Element::S])
 					&& (bond_it->getSecondAtom()->getElement() == PTE[Element::S])
-					&& (residue1->hasProperty(Residue::PROPERTY__HAS_SSBOND) == true)
-					&& (residue2->hasProperty(Residue::PROPERTY__HAS_SSBOND) == true)
+					&& residue1->hasProperty(Residue::PROPERTY__HAS_SSBOND)
+					&& residue2->hasProperty(Residue::PROPERTY__HAS_SSBOND)
 					&& (residue1 != residue2)
 					&& (residue1 != 0)
 					&& (residue2 != 0))

--- a/source/STRUCTURE/geometricProperties.C
+++ b/source/STRUCTURE/geometricProperties.C
@@ -163,13 +163,7 @@ namespace BALL
 		fragments.clear();
 
 		// if no reference fragment is set, return immediately
-		if (reference_composite_ == 0)
-		{
-			return false;
-		}
-
-		// Go for it...
-		return true;
+		return reference_composite_ != 0;
 	}
 
 	float FragmentDistanceCollector::getDistance() const
@@ -235,14 +229,14 @@ namespace BALL
 			}
 			fragment_radius = sqrt(fragment_radius);
 
-			for ( j=0 , collect_it = false ; j < number_of_atoms && (collect_it == false) ; j++) 
+			for (j = 0, collect_it = false; j < number_of_atoms && !collect_it; j++)
 			{
 				atom_position = reference_atoms[j]->getPosition();
 				 
 				if (atom_position.getDistance(center) <= (distance + fragment_radius)) 
 				{
 					for (atom_iterator2 = mol_fragment->beginAtom(); 
-							 +atom_iterator2 && (collect_it == false); ++ atom_iterator2)
+							 +atom_iterator2 && (!collect_it); ++ atom_iterator2)
 					{
 						if ((*atom_iterator2).getPosition().getSquareDistance(atom_position) < squared_distance_) 
 						{

--- a/source/STRUCTURE/peptideBuilder.C
+++ b/source/STRUCTURE/peptideBuilder.C
@@ -226,7 +226,7 @@ namespace BALL
 				// special case: residue is a proline
 				type = i->getType();
 				type.toUpper();
-				is_proline_ = (type == "PRO") ? true : false;
+				is_proline_ = type == "PRO";
 
 				Residue* residue2 = createResidue_(i->getType(), id);
 

--- a/source/STRUCTURE/rGroupAssembler.C
+++ b/source/STRUCTURE/rGroupAssembler.C
@@ -120,11 +120,7 @@ namespace BALL
 				it->second = 0;
 		}
 			scaffold_counter_++;
-		if (scaffold_counter_ < scaffolds_.size())
-		{
-			return true;
-		}
-		return false;
+		return scaffold_counter_ < scaffolds_.size();
 	}
 		bool RGroupAssembler::isPlacemark_(const String& s)
 	{

--- a/source/STRUCTURE/reconstructFragmentProcessor.C
+++ b/source/STRUCTURE/reconstructFragmentProcessor.C
@@ -294,7 +294,7 @@ namespace BALL
 										<< " / " << (ref_atoms.third == 0 ? String("-") : ref_atoms.third->getFullName()))
 
 							Matrix4x4 T;
-							if (ref_atoms.first == true)
+							if (ref_atoms.first)
 							{
 								// we can map all three atoms, great!
 								DEBUG("mapping three atoms: " << tpl_to_res[current]->getFullName() << "/" 

--- a/source/STRUCTURE/reducedSurface.C
+++ b/source/STRUCTURE/reducedSurface.C
@@ -718,7 +718,7 @@ namespace BALL
 		{
 			if (rs_->faces_[i] != NULL)
 			{
-				if (treatFace(rs_->faces_[i]) == false)
+				if (!treatFace(rs_->faces_[i]))
 				{
 					i = 0;
 				}
@@ -983,7 +983,7 @@ namespace BALL
 			HashSet<RSVertex*>::Iterator test;
 			for (test = test_vertices.begin(); test != test_vertices.end(); test++)
 			{
-				if ((*test)->hasEdges() == false)
+				if (!(*test)->hasEdges())
 				{
 					rs_->vertices_[(*test)->index_] = NULL;
 					vertices_[(*test)->atom_].remove(*test);
@@ -1053,7 +1053,7 @@ namespace BALL
 							{
 								Index atom3 = j->first;
 								TSphere3<double> probe = j->second;
-								if (checkProbe(probe,SortedPosition3(atom1,atom2,atom3)) == true)
+								if (checkProbe(probe,SortedPosition3(atom1,atom2,atom3)))
 								{
 									face = new RSFace;
 									RSEdge* edge1 = new RSEdge;
@@ -1288,7 +1288,7 @@ namespace BALL
 		Index a3 = -1;
 		TSphere3<double> probe;
 		bool found = false;
-		while ((found == false) && (i != candidates.end()))
+		while (!found && i != candidates.end())
 		{
 			a3 = i->first;
 			probe = i->second;
@@ -1369,7 +1369,7 @@ namespace BALL
 		// find the first atom of unknown status
 		Index i = 0;
 		bool found = false;
-		while ((found == false) && (i < (Index)rs_->number_of_atoms_))
+		while (!found && i < (Index)rs_->number_of_atoms_)
 		{
 			if (atom_status_[i] == STATUS_UNKNOWN)
 			{
@@ -1416,7 +1416,7 @@ namespace BALL
 		// find the first neighbour atom of unknown status
 		std::deque<Index>::const_iterator i = neighbours_[atom].begin();
 		bool found = false;
-		while ((found == false) && (i != neighbours_[atom].end()))
+		while (!found && i != neighbours_[atom].end())
 		{
 			if (atom_status_[*i] == STATUS_UNKNOWN)
 			{

--- a/source/STRUCTURE/solventExcludedSurface.C
+++ b/source/STRUCTURE/solventExcludedSurface.C
@@ -166,14 +166,14 @@ namespace BALL
 					{
 						if (face->type_ == SESFace::TYPE_TORIC_SINGULAR)
 						{
-							if (cleanSingularToricFace(face,sqrt_density) == false)
+							if (!cleanSingularToricFace(face,sqrt_density))
 							{
 								done = false;
 							}
 						}
 						else
 						{
-							if (cleanToricFace(face,sqrt_density) == false)
+							if (!cleanToricFace(face,sqrt_density))
 							{
 								done = false;
 							}
@@ -1738,7 +1738,7 @@ namespace BALL
 	{
 		for (Position i = 0; i < ses_->number_of_spheric_faces_; i++)
 		{
-			if (ses_->spheric_faces_[i]->rsface_->singular_ == true)
+			if (ses_->spheric_faces_[i]->rsface_->singular_)
 			{
 				faces.push_back(ses_->spheric_faces_[i]);
 			}
@@ -2261,15 +2261,8 @@ namespace BALL
 			{
 				double epsilon = Constants::EPSILON;
 				Constants::EPSILON = 1e-6;
-				if (Maths::isGreater(probe.p.getSquareDistance(middle),
-														 probe.radius*probe.radius))
-				{
-					back = false;
-				}
-				else
-				{
-					back = true;
-				}
+				back = !Maths::isGreater(probe.p.getSquareDistance(middle),
+														 probe.radius*probe.radius);
 				Constants::EPSILON = epsilon;
 			}
 		}
@@ -2473,7 +2466,7 @@ namespace BALL
 				m++;
 			}
 		}
-		if (spheric_face1->isNeighbouredTo(spheric_face2) == false)
+		if (!spheric_face1->isNeighbouredTo(spheric_face2))
 		{
 			point1.set(vertex->point_);
 			if (new_vertex == NULL)
@@ -2566,7 +2559,7 @@ namespace BALL
 			}
 		}
 		// if the intersection points are not computed yet, compute them now
-		if (found == false)
+		if (!found)
 		{
 			TSphere3<double> s1(ses_->spheric_faces_[face1]->rsface_->center_,
 								 ses_->reduced_surface_->probe_radius_);

--- a/source/STRUCTURE/structureMapper.C
+++ b/source/STRUCTURE/structureMapper.C
@@ -424,19 +424,19 @@ namespace BALL
 		// searching the backbone atoms of residue r1
 		for (atom_it = r1.beginAtom(); +atom_it; ++atom_it)
 		{
-			if (got_p1_r1 == false && atom_it->getName() == "CA")
+			if (!got_p1_r1 && atom_it->getName() == "CA")
 			{
 				p1_r1 = atom_it->getPosition();
 				got_p1_r1 = true;
 				counter++;
 			}
-			if (got_p2_r1 == false && atom_it->getName() == "N")
+			if (!got_p2_r1 && atom_it->getName() == "N")
 			{
 				p2_r1 = atom_it->getPosition();
 				got_p2_r1 = true;
 				counter++;
 			}
-			if (got_p3_r1 == false && atom_it->getName() == "C")
+			if (!got_p3_r1 && atom_it->getName() == "C")
 			{
 				p3_r1 = atom_it->getPosition();
 				got_p3_r1 = true;
@@ -447,19 +447,19 @@ namespace BALL
 		// searching the backbone atoms of residue r2
 		for (atom_it = r2.beginAtom(); +atom_it; ++atom_it)
 		{
-			if (got_p1_r2 == false && atom_it->getName() == "CA")
+			if (!got_p1_r2 && atom_it->getName() == "CA")
 			{
 				p1_r2 = atom_it->getPosition();
 				got_p1_r2 = true;
 				counter++;
 			}
-			if (got_p2_r2 == false && atom_it->getName() == "N")
+			if (!got_p2_r2 && atom_it->getName() == "N")
 			{
 				p2_r2 =(*atom_it).getPosition();
 				got_p2_r2 = true;
 				counter++;
 			}
-			if (got_p3_r2 == false && atom_it->getName() == "C")
+			if (!got_p3_r2 && atom_it->getName() == "C")
 			{
 				p3_r2 = atom_it->getPosition();
 				got_p3_r2 = true;
@@ -599,7 +599,7 @@ namespace BALL
 
 		result = new vector < vector < Fragment * > >;
 
-		for(i = 0; i < no_of_frag && ready == false; i++)
+		for(i = 0; i < no_of_frag && !ready; i++)
 		{
 			for(j = 0, counter = 0; j < no_of_comp_frag; ++j)
 			{
@@ -632,7 +632,7 @@ namespace BALL
 			indices_of_pot_pattern[i] = indices_CF[i][j];
 			distances_fit = true;
 
-			for(k = 0; k < i && distances_fit == true; k++)
+			for(k = 0; k < i && distances_fit; k++)
 			{
 				distance = pattern_distances[i * no_of_frag + k] -
 				comp_frag_dist[indices_of_pot_pattern[i] * no_of_comp_frag + indices_of_pot_pattern[k]];
@@ -642,7 +642,7 @@ namespace BALL
 				}
 			}
 
-			if (distances_fit == true)
+			if (distances_fit)
 			{
 				index_stack.push(j);
 				i++;

--- a/source/STRUCTURE/triangulatedSES.C
+++ b/source/STRUCTURE/triangulatedSES.C
@@ -1004,7 +1004,7 @@ namespace BALL
 		while (e != sesedge.end())
 		{
 			found = false;
-			while ((found == false) && (e != sesedge.end()))
+			while (!found && e != sesedge.end())
 			{
 				if ((*e)->type_ == SESEdge::TYPE_SINGULAR)
 				{
@@ -1056,7 +1056,7 @@ namespace BALL
 		bool old1, old2;
 		createTriangleAndEdges(edge,point,sphere,
 													 edge1,old1,edge2,old2,triangle,convex);
-		if (old1 == true)
+		if (old1)
 		{
 			if (edge1->face_[0] == NULL)
 			{
@@ -1077,7 +1077,7 @@ namespace BALL
 			part.number_of_edges_++;
 			border.push_back(edge1);
 		}
-		if (old2 == true)
+		if (old2)
 		{
 			if (edge2->face_[0] == NULL)
 			{
@@ -1133,7 +1133,7 @@ namespace BALL
 			planar_edges.pop_front();
 			p = points.begin();
 			bool built = false;
-			while ((p != points.end()) && (built == false))
+			while (p != points.end() && !built)
 			{
 				if ((*p == edge0->vertex_[0]) || (*p == edge0->vertex_[1]))
 				{
@@ -1180,7 +1180,7 @@ namespace BALL
 						triangle->vertex_[0]->faces_.insert(triangle);
 						triangle->vertex_[1]->faces_.insert(triangle);
 						triangle->vertex_[2]->faces_.insert(triangle);
-						if (old1 == true)
+						if (old1)
 						{
 							if (edge1->face_[0] == NULL)
 							{
@@ -1203,7 +1203,7 @@ namespace BALL
 							part.edges_.push_back(edge1);
 							part.number_of_edges_++;
 						}
-						if (old2 == true)
+						if (old2)
 						{
 							if (edge2->face_[0] == NULL)
 							{
@@ -1234,11 +1234,11 @@ namespace BALL
 					{
 						p++;
 						delete triangle;
-						if (old1 == false)
+						if (!old1)
 						{
 							delete edge1;
 						}
-						if (old2 == false)
+						if (!old2)
 						{
 							delete edge2;
 						}

--- a/source/STRUCTURE/triangulatedSurface.C
+++ b/source/STRUCTURE/triangulatedSurface.C
@@ -1067,10 +1067,8 @@ namespace BALL
 		{
 			TVector3<double> norm(((*t)->vertex_[1]->point_-(*t)->vertex_[0]->point_) %
 											 ((*t)->vertex_[2]->point_-(*t)->vertex_[0]->point_)	);
-			if ((Maths::isGreater(norm*(*t)->vertex_[0]->point_,0) &&
-					 (out == false)																				) ||
-					(Maths::isLess(norm*(*t)->vertex_[0]->point_,0) &&
-					 (out == true)																				)		)
+			if ((!out && Maths::isGreater(norm*(*t)->vertex_[0]->point_, 0)) ||
+			    ( out && Maths::isLess   (norm*(*t)->vertex_[0]->point_, 0)))
 			{
 				TrianglePoint* temp = (*t)->vertex_[1];
 				(*t)->vertex_[1] = (*t)->vertex_[2];
@@ -1105,7 +1103,7 @@ namespace BALL
 			TrianglePoint* point2 = (*e)->vertex_[1];
 			TrianglePoint* new_point = new TrianglePoint;
 			new_point->point_ = (point1->point_+point2->point_).normalize();
-			if (out == true)
+			if (out)
 			{
 				new_point->normal_ = new_point->point_;
 			}

--- a/source/SYSTEM/file.C
+++ b/source/SYSTEM/file.C
@@ -379,12 +379,12 @@ namespace BALL
 
 	void File::close()
 	{
-		if (is_open_ == true)
+		if (is_open_)
 		{
 			std::fstream::clear();
 			std::fstream::close();
 
-			if (is_temporary_ == true)
+			if (is_temporary_)
 			{
 				remove(name_);
 				is_temporary_ = false;
@@ -438,7 +438,7 @@ namespace BALL
 			}
 		#else
 			struct stat stats;
-			if ((trace_link == true) 
+			if (trace_link
 					?  ::stat(name.c_str(), &stats) < 0
 					: ::lstat(name.c_str(), &stats) < 0)
 			{ 

--- a/source/SYSTEM/fileSystem.C
+++ b/source/SYSTEM/fileSystem.C
@@ -63,7 +63,7 @@ namespace BALL
 		// remove a leading "./"
 		s.set(FileSystem::CURRENT_DIRECTORY);
 		s += "/";
-		while (path.hasPrefix(s) == true)
+		while (path.hasPrefix(s))
 		{
 			path.erase(0, s.size());	
 		}
@@ -71,7 +71,7 @@ namespace BALL
 		// remove trailing "/."
 		s.set("/");
 		s += FileSystem::CURRENT_DIRECTORY;
-		while (path.hasSuffix(s) == true)
+		while (path.hasSuffix(s))
 		{
 			path.resize(path.size() - s.size());
 		}
@@ -92,7 +92,7 @@ namespace BALL
 
 		RegularExpression reg_exp(s);
 		Substring sub;
-		while (reg_exp.find(path, sub) == true)
+		while (reg_exp.find(path, sub))
 		{
 			sub.destroy();
 		}
@@ -101,7 +101,7 @@ namespace BALL
 	void FileSystem::expandTilde_(String& path)
 	{
 		#ifndef BALL_COMPILER_MSVC
-		if (path.isEmpty() == true)
+		if (path.isEmpty())
 		{
 			return;
 		}

--- a/source/SYSTEM/timer.C
+++ b/source/SYSTEM/timer.C
@@ -103,7 +103,7 @@ namespace BALL
 
 	bool Timer::start()
 	{
-		if (is_running_ == true)
+		if (is_running_)
 		{ 
 			/* tried to start a running timer */
 			return false;
@@ -151,7 +151,7 @@ namespace BALL
 
 	bool Timer::stop()
 	{
-		if (is_running_ == false)
+		if (!is_running_)
 		{ /* tried to stop a stopped timer */
 			return false;
 		}
@@ -200,7 +200,7 @@ namespace BALL
 
 	void Timer::reset()
 	{
-		if (is_running_ == false)
+		if (!is_running_)
 		{
 			clear();
 		} 
@@ -225,7 +225,7 @@ namespace BALL
 		LongIndex elapsed_seconds;
 		LongIndex elapsed_useconds;
 
-		if (is_running_ == false)
+		if (!is_running_)
 		{ 
 			/* timer is currently off, so just return accumulated time */
 			elapsed_seconds = current_secs_;
@@ -286,7 +286,7 @@ namespace BALL
 		#else
 			struct tms tms_buffer;	
 		#endif
-		if (is_running_ == false)
+		if (!is_running_)
 		{ 
 			/* timer is off, just return accumulated time */
 			temp_value = (double)current_user_time_;
@@ -339,7 +339,7 @@ namespace BALL
 			FILETIME kt,ut,ct,et;
 		#endif												
 		
-		if (is_running_ == false)
+		if (!is_running_)
 		{ 
 			/* timer is off, just return accumulated time */
 			temp_value = (double)current_system_time_;

--- a/source/TEST/Directory_test.C
+++ b/source/TEST/Directory_test.C
@@ -55,15 +55,7 @@ bool cleanup()
 	d.remove("test3" + PS + "test4");
 	d.remove("test3");
 
-	if (d.has("test1") ||
-			d.has("test2") ||
-			d.has("test3"))
-	{
-				return false;
-
-	}
-
-	return true;
+	return !(d.has("test1") || d.has("test2") || d.has("test3"));
 }
 
 
@@ -243,7 +235,7 @@ CHECK(bool getNextEntry(String& entry))
 	STATUS("getNextEntry : " << result << " = " << s)
 	TEST_EQUAL(result, true)
 	bool found_test2 = false;
-	while (result == true)
+	while (result)
 	{
 		if ((s != ".") && (s != ".."))
 		{

--- a/source/TEST/RotamerLibrary_test.C
+++ b/source/TEST/RotamerLibrary_test.C
@@ -331,7 +331,7 @@ CHECK(Side chain conformations for Dunbrack library)
 				TEST_EQUAL(rc.getStatus(), true)
 
 				// Store suspicious conformations for subsequent debugging.
-				if (rc.getStatus() == false)
+				if (!rc.getStatus())
 				{
 					String outfile_name;
 					NEW_TMP_FILE(outfile_name)

--- a/source/VIEW/KERNEL/compositeManager.C
+++ b/source/VIEW/KERNEL/compositeManager.C
@@ -73,9 +73,7 @@ namespace BALL
 
 		bool CompositeManager::hasRoot(const Composite* composite) const
 		{
-			if (composite_set_.has((Composite*) &composite)) return true;
-
-			return false;
+			return composite_set_.has((Composite*) &composite);
 		}
 
 

--- a/source/VIEW/KERNEL/modelInformation.C
+++ b/source/VIEW/KERNEL/modelInformation.C
@@ -114,14 +114,9 @@ namespace BALL
 
 		bool ModelInformation::isSurfaceModel(ModelType type) const
 		{
-			if (type == MODEL_SE_SURFACE || 
-					type == MODEL_SA_SURFACE ||
-					type == MODEL_CONTOUR_SURFACE)
-			{
-				return true;
-			}
-
-			return false;
+			return type == MODEL_SE_SURFACE
+			    || type == MODEL_SA_SURFACE
+			    || type == MODEL_CONTOUR_SURFACE;
 		}
 
 

--- a/source/VIEW/KERNEL/preferencesEntry.C
+++ b/source/VIEW/KERNEL/preferencesEntry.C
@@ -102,13 +102,8 @@ namespace BALL
 				return true;
 			}
 
-			QGroupBox* box = dynamic_cast<QGroupBox*>(&widget);
-			if (box != 0 && (box->isCheckable() || box->findChildren<QRadioButton*>().size()))
-			{
-				return true;
-			}
-
-			return false;
+			QGroupBox* box = qobject_cast<QGroupBox*>(&widget);
+			return box != 0 && (box->isCheckable() || !box->findChildren<QRadioButton*>().empty());
 		}
 
 		void PreferencesEntry::writePreferenceEntries(INIFile& inifile)

--- a/source/VIEW/WIDGETS/scene.C
+++ b/source/VIEW/WIDGETS/scene.C
@@ -1613,12 +1613,7 @@ namespace BALL
 
 		bool Scene::isAnimationRunning() const
 		{
-			if (animation_thread_ != 0 && animation_thread_->isRunning())
-			{
-				return true;
-			}
-
-			return false;
+			return animation_thread_ != 0 && animation_thread_->isRunning();
 		}
 
 		//##########################EVENTS#################################


### PR DESCRIPTION
Fixes a truck load of clang-tidy complaints about overcomplicated boolean expressions. This should make some code much more cleaner and readable. Most changes were performed by the tool itself with some manual reformatting. I checked all changes, but it would be nice if someone could try to spot possible errors I made during the conversion.