### PR TITLE
Remove exception specifications

### DIFF
--- a/include/BALL/COMMON/exception.h
+++ b/include/BALL/COMMON/exception.h
@@ -543,8 +543,10 @@ namespace BALL
 			/// The BALL replacement for terminate
 			static void terminate();
 
-			/// The BALL new handler
-			static void newHandler() throw(Exception::OutOfMemory);
+			/** The BALL new handler
+			 *  @throws BALL::Exception::OutOfMemory
+			 */
+			static void newHandler();
 
 			static std::string file_;
 			static int				 line_;

--- a/include/BALL/DOCKING/COMMON/dockResult.h
+++ b/include/BALL/DOCKING/COMMON/dockResult.h
@@ -97,11 +97,11 @@ namespace BALL
 				ConformationSet* getConformationSet()
 					throw();
 
-				/*  Sets scoring flag by which all scores are sorted displayed
+				/** Sets scoring flag by which all scores are sorted displayed
 						a negative index corresponds to sorting by snapshot index
+						@throws BALL::Exception::IndexOverflow
 				 */
-				 void sortBy(Index scoring_index)
-					throw(Exception::IndexOverflow);
+				 void sortBy(Index scoring_index);
 
 				/*  Get the number of the scoring by which all scores are sorted displayed
 				 */
@@ -110,24 +110,24 @@ namespace BALL
 
 				/** Returns score i of the scoring j in respect of the current sorting
 				 *  indicated by the flag \link DockResult::sorted_by_ sorted_by_ \endlink.
+				 *  @throws BALL::Exception::IndexOverflow
 				 */
-				float operator()(Position i, Position j)
-					throw(Exception::IndexOverflow);
+				float operator()(Position i, Position j);
 
 				/** Returns the scores of \link DockResult::Scoring_ scoring \endlink i.
+				    @throws BALL::Exception::IndexOverflow
 				*/
-				const vector < ConformationSet::Conformation > getScores(Position i) const
-					throw(Exception::IndexOverflow);
+				const vector < ConformationSet::Conformation > getScores(Position i) const;
 
 				/** Returns the name of scoring function of \link DockResult::Scoring_ scoring \endlink i.
+				    @throws BALL::Exception::IndexOverflow
 				*/
-				const String& getScoringName(Position i) const
-					throw(Exception::IndexOverflow);
+				const String& getScoringName(Position i) const;
 
 				/** Returns the scoring function options of \link DockResult::Scoring_ scoring \endlink i.
+				    @throws BALL::Exception::IndexOverflow
 				*/
-				const Options& getScoringOptions(Position i) const
-					throw(Exception::IndexOverflow);
+				const Options& getScoringOptions(Position i) const;
 
 				/** Returns the number of scorings.
 				*/
@@ -143,9 +143,9 @@ namespace BALL
 					throw();
 
 				/** Deletes Scoring_ i of vector \link DockResult::scorings_ scorings_ \endlink.
+				    @throws BALL::Exception::IndexOverflow
 				*/
-				void deleteScoring(Position i)
-					throw(Exception::IndexOverflow);
+				void deleteScoring(Position i);
 
 				//@}
 

--- a/include/BALL/DOCKING/COMMON/result.h
+++ b/include/BALL/DOCKING/COMMON/result.h
@@ -124,14 +124,16 @@ namespace BALL
 			/** Get the input conformation of the result for a specific Ligand.
 					@param  pointer to Ligand
 					@return pointer to input Conformation
+					@throws BALL::Exception::GeneralException
 			 */
-			Conformation* getInputConformer(Ligand* lig) throw(Exception::GeneralException);
+			Conformation* getInputConformer(Ligand* lig);
 
 			/** Get the first output conformation of the result for a specific Ligand.
 					@param  pointer to Ligand
 					@return  pointer to first output Conformation
+					@throws BALL::Exception::GeneralException
 			 */
-			Conformation* getFirstOutputConformation(Ligand* lig) throw(Exception::GeneralException);
+			Conformation* getFirstOutputConformation(Ligand* lig);
 
 			/** Get the all output conformation of the result for a specific Ligand.
 					@param  pointer to Ligand

--- a/include/BALL/FORMAT/dockResultFile.h
+++ b/include/BALL/FORMAT/dockResultFile.h
@@ -36,8 +36,9 @@ namespace BALL
 
 				/** Read receptor object.
 							@return Receptor* pointer to the read Receptor object
+							@throws BALL::Exception::ParseError
 				 */
-				Receptor* readReceptor() throw(Exception::ParseError);
+				Receptor* readReceptor();
 
 				/** Write receptor object (directly).
 							@param pointer to Receptor object
@@ -46,8 +47,9 @@ namespace BALL
 
 				/** Read receptor object.
 							@return Ligand* pointer to the read Ligand object
+							@throws BALL::Exception::ParseError
 				 */
-				Ligand* readLigand() throw(Exception::ParseError);
+				Ligand* readLigand();
 
 				/** Write Ligand object (directly).
 							@param pointer to Ligand object
@@ -66,8 +68,9 @@ namespace BALL
 
 				/** Read result objects.
 							@return vector of Result pointers
+							@throws BALL::Exception::ParseError
 				 */
-				vector<Result*> readResults() throw(Exception::ParseError);
+				vector<Result*> readResults();
 
 				/**	Close file.  */
 				void close();
@@ -82,8 +85,11 @@ namespace BALL
 				/**	@name GenericMolecule interface functions */
 				//@{
 
-				Molecule* read() throw (Exception::ParseError);
-				bool write(const Molecule& mol) throw (File::CannotWrite);
+				/// @throws BALL::Exception::ParseError
+				Molecule* read();
+
+				/// @throws BALL::File::CannotWrite
+				bool write(const Molecule& mol);
 
 				void setOutputParameters(Result::Method, String property_name, String& receptor_conf_UID, String method_description="");
 
@@ -196,17 +202,17 @@ namespace BALL
 				void writeFlexibility(const FlexDefinition &fd, QXmlStreamWriter &out);
 				void writeRotamericFlexibleResidue(Position idx, QXmlStreamWriter &out);
 				void writeFullyFlexibleResidue(Position idx, QXmlStreamWriter &out);
-				// receptor read
-				bool readReceptors_() throw(Exception::ParseError);
-				bool readReceptor_() throw(Exception::ParseError);
-				bool readProtein() throw(Exception::ParseError);
-				bool readResidue() throw(Exception::ParseError);
-				bool readPDBAtom() throw(Exception::ParseError);
-				// result read
-				bool readResults_() throw(Exception::ParseError);
-				bool readResult() throw(Exception::ParseError);
-				bool readSubResult() throw(Exception::ParseError);
-				bool readEntry() throw(Exception::ParseError);
+				// receptor read (might throw BALL::Exception::ParseError)
+				bool readReceptors_();
+				bool readReceptor_();
+				bool readProtein();
+				bool readResidue();
+				bool readPDBAtom();
+				// result read (might throw BALL::Exception::ParseError)
+				bool readResults_();
+				bool readResult();
+				bool readSubResult();
+				bool readEntry();
 				// result write
 				void writeResults(QXmlStreamWriter &out);
 				void writeResult(Result* result, QXmlStreamWriter &out);
@@ -217,28 +223,28 @@ namespace BALL
 				void writeMolecule(Molecule* mol, QXmlStreamWriter &out);
 				void writeAtom(Atom* at, QXmlStreamWriter &out);
 				void writeBond(Bond* b, QXmlStreamWriter &out);
-				// ligand read
-				bool readLigands() throw(Exception::ParseError);
-				bool readLigand_() throw(Exception::ParseError);
-				bool readMolecule() throw(Exception::ParseError);
-				bool readConformations(FlexibleMolecule* target) throw(Exception::ParseError);
-				bool readConformation(Conformation* conformation) throw(Exception::ParseError);
-				bool readCoordinates() throw(Exception::ParseError);
-				bool readFlexibility() throw(Exception::ParseError);
-				bool readFlexibilities() throw(Exception::ParseError);
-				bool readFullFlexResidue() throw(Exception::ParseError);
-				bool readRotamericResidue() throw(Exception::ParseError);
-				bool readAtoms() throw(Exception::ParseError);
-				bool readAtom() throw(Exception::ParseError);
-				bool readBonds() throw(Exception::ParseError);
-				bool readBond() throw(Exception::ParseError);
+				// ligand read (might throw BALL::Exception::ParseError)
+				bool readLigands();
+				bool readLigand_();
+				bool readMolecule();
+				bool readConformations(FlexibleMolecule* target);
+				bool readConformation(Conformation* conformation);
+				bool readCoordinates();
+				bool readFlexibility();
+				bool readFlexibilities();
+				bool readFullFlexResidue();
+				bool readRotamericResidue();
+				bool readAtoms();
+				bool readAtom();
+				bool readBonds();
+				bool readBond();
 
-				// building
-				void buildLigand() throw(Exception::ParseError);
-				void buildMolecule() throw(Exception::ParseError);
-				void buildReceptor() throw(Exception::ParseError);
-				void buildProtein() throw(Exception::ParseError);
-				void buildResidue() throw(Exception::ParseError);
+				// building (might throw BALL::Exception::ParseError)
+				void buildLigand();
+				void buildMolecule();
+				void buildReceptor();
+				void buildProtein();
+				void buildResidue();
 
 				// helper methods
 				bool retrieveInt(const String& s, int &out);

--- a/include/BALL/MOLMEC/AMBER/GAFFTypeProcessor.h
+++ b/include/BALL/MOLMEC/AMBER/GAFFTypeProcessor.h
@@ -100,9 +100,9 @@ namespace BALL
 			 *  and store a GAFFCESParser for every CESstring.
 			 *  The path to the atom type file is taken from the value
 			 *  of the option ATOMTYPE_FILENAME.
+			 *  @throws BALL::Exception::FileNotFound
 			 */
-			void parseAtomtypeTableFile_()
-				throw(Exception::FileNotFound);
+			void parseAtomtypeTableFile_();
 
 			/// compute aromaticity, ring memberships, GAFF bond typization, ...
 			void precomputeBondProperties_(Molecule* molecule);

--- a/include/BALL/MOLMEC/AMBER/amber.h
+++ b/include/BALL/MOLMEC/AMBER/amber.h
@@ -212,9 +212,9 @@ namespace BALL
 		//@{
 
 		/**	Force field specific setup
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool specificSetup()
-			throw(Exception::TooManyErrors);
+		virtual bool specificSetup();
 
 		//@}
 		/**	@name Accessors specific to the AMBER force field

--- a/include/BALL/MOLMEC/AMBER/amberBend.h
+++ b/include/BALL/MOLMEC/AMBER/amberBend.h
@@ -52,9 +52,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 	};

--- a/include/BALL/MOLMEC/AMBER/amberNonBonded.h
+++ b/include/BALL/MOLMEC/AMBER/amberNonBonded.h
@@ -103,9 +103,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 
 		/** Setup this component according to the given options and store the ForceFieldParameters in par */
@@ -131,9 +131,9 @@ namespace BALL
 				This method is called by the force field whenever
 				 \link ForceField::update ForceField::update \endlink  is called. It is used
 				to recalculate the nonbonded pair list.
+				@throws BALL::Exception::TooManyErrors
 		*/
-		virtual void update()
-			throw(Exception::TooManyErrors);
+		virtual void update();
 
 
 		/** Update this component using the given atom-pairs only */
@@ -162,12 +162,12 @@ namespace BALL
 			;
 
 		/**	Build a vector of non-bonded atom pairs with the vdw parameters
+		 * @throws BALL::Exception::TooManyErrors
 		*/
 		virtual void buildVectorOfNonBondedAtomPairs
 			(const std::vector<std::pair<Atom*, Atom*> >& atom_vector,
 			 const LennardJones& lennard_jones,
-			 const Potential1210& hydrogen_bond)
-			throw(Exception::TooManyErrors);
+			 const Potential1210& hydrogen_bond);
 
 		//@}
 

--- a/include/BALL/MOLMEC/AMBER/amberStretch.h
+++ b/include/BALL/MOLMEC/AMBER/amberStretch.h
@@ -51,8 +51,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup() throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 	};

--- a/include/BALL/MOLMEC/AMBER/amberTorsion.h
+++ b/include/BALL/MOLMEC/AMBER/amberTorsion.h
@@ -106,9 +106,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 		/**	@name	Accessors	

--- a/include/BALL/MOLMEC/CHARMM/charmm.h
+++ b/include/BALL/MOLMEC/CHARMM/charmm.h
@@ -231,9 +231,9 @@ namespace BALL
 		//@{
 
 		/**	Force field specific setup
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool specificSetup()
-			throw(Exception::TooManyErrors);
+		virtual bool specificSetup();
 
 		//@}
 		/**	@name	Accessors specific to the CHARMM force field

--- a/include/BALL/MOLMEC/CHARMM/charmmBend.h
+++ b/include/BALL/MOLMEC/CHARMM/charmmBend.h
@@ -51,9 +51,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 		//@}
 	};
 } // namespace BALL

--- a/include/BALL/MOLMEC/CHARMM/charmmImproperTorsion.h
+++ b/include/BALL/MOLMEC/CHARMM/charmmImproperTorsion.h
@@ -78,9 +78,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 		/**	@name	Accessors	

--- a/include/BALL/MOLMEC/CHARMM/charmmNonBonded.h
+++ b/include/BALL/MOLMEC/CHARMM/charmmNonBonded.h
@@ -108,9 +108,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 		/**	@name	Accessors	
@@ -154,10 +154,10 @@ namespace BALL
 			;
 
 		/**	Build a vector of non-bonded atom pairs with the vdw parameters
+		 * @throws BALL::Exception::TooManyErrors
 		*/
 		virtual void buildVectorOfNonBondedAtomPairs
-			(const std::vector<std::pair<Atom*, Atom*> >& atom_vector)
-			throw(Exception::TooManyErrors);
+			(const std::vector<std::pair<Atom*, Atom*> >& atom_vector);
 
 		//@}
 

--- a/include/BALL/MOLMEC/CHARMM/charmmStretch.h
+++ b/include/BALL/MOLMEC/CHARMM/charmmStretch.h
@@ -51,8 +51,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup() throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 	};

--- a/include/BALL/MOLMEC/CHARMM/charmmTorsion.h
+++ b/include/BALL/MOLMEC/CHARMM/charmmTorsion.h
@@ -111,9 +111,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 		/**	@name	Accessors	

--- a/include/BALL/MOLMEC/COMMON/forceField.h
+++ b/include/BALL/MOLMEC/COMMON/forceField.h
@@ -172,9 +172,9 @@ namespace BALL
 
 		/**	Force field specific setup.
 				This method is called by setup.
+				@throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool specificSetup()
-			throw(Exception::TooManyErrors);
+		virtual bool specificSetup();
 
 		/** Set the number of atoms, for which the setup of the forcefield can
 		    fail, until the setup() methods aborts and return false.
@@ -337,9 +337,9 @@ namespace BALL
 				between two calls to update. \par
 				The default implementation calls  \link ForceFieldComponent::update ForceFieldComponent::update \endlink  for
 				each component in the force field.
+				@throws BALL::Exception::TooManyErrors
 		*/
-		virtual void update()
-			throw(Exception::TooManyErrors);
+		virtual void update();
 
 		/** Get the current results in String form
 		 		(Generic function to be overloaded in derived classes.)
@@ -348,7 +348,7 @@ namespace BALL
 			 { return "undefined";}
 
 		//_ Report an error and increase the error counter
-		std::ostream& error() throw(Exception::TooManyErrors);
+		std::ostream& error();
 
 		//@}
 		/**	@name	Public Attributes

--- a/include/BALL/MOLMEC/COMMON/forceFieldComponent.h
+++ b/include/BALL/MOLMEC/COMMON/forceFieldComponent.h
@@ -72,8 +72,7 @@ namespace BALL
 
 		/**	Setup method.
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 		/**	@name	Accessors	
@@ -134,9 +133,9 @@ namespace BALL
 				this method. It is called for each component of a force field
 				each time  \link ForceField::update ForceField::update \endlink  is called.
 				The default implementation does exactly nothing.
+				@throws BALL::Exception::TooManyErrors
 		*/
-		virtual void update()
-			throw(Exception::TooManyErrors);
+		virtual void update();
 
 		/** interface to ScoringComponent */
 		double updateScore();

--- a/include/BALL/MOLMEC/COMMON/snapShot.h
+++ b/include/BALL/MOLMEC/COMMON/snapShot.h
@@ -121,9 +121,9 @@ namespace BALL
 		/** Take a SnapShot from a system. Copy all positions, velocities and
 				forces from the System <tt>system</tt> to this instance of SnapShot.
 				@param system the System from which to take the data
+				@throws BALL::Exception::OutOfMemory
 		*/
-		void takeSnapShot(const System& system)
-			throw(Exception::OutOfMemory);
+		void takeSnapShot(const System& system);
 
 		/** Apply the data contained in a SnapShot to a System. Copy all
 				available data to the system. <b>Note</b> that some trajectory file
@@ -137,9 +137,9 @@ namespace BALL
 		/** Read all atom positions from a System and store them in this
 				instance of SnapShot.
 				@param system the System from which data will be read
+				@throws BALL::Exception::OutOfMemory
 		*/
-		void getAtomPositions(const System& system)
-			throw(Exception::OutOfMemory);
+		void getAtomPositions(const System& system);
 
 		/** Set all Atom positions of a System to the values stored in this
 				instance of SnapShot.
@@ -150,9 +150,9 @@ namespace BALL
 		/** Read all atom velocities from a System and store them in this
 				instance of SnapShot.
 				@param system the System from which data will be read
+				@throws BALL::Exception::OutOfMemory
 		*/
-		void getAtomVelocities(const System& system)
-			throw(Exception::OutOfMemory);
+		void getAtomVelocities(const System& system);
 
 		/** Set all Atom velocities of a System to the values stored in this
 				instance of SnapShot.
@@ -163,9 +163,9 @@ namespace BALL
 		/** Read all atom forces from a System and store them in this
 				instance of SnapShot.
 				@param system the System from which data will be read
+				@throws BALL::Exception::OutOfMemory
 		*/
-		void getAtomForces(const System& system)
-			throw(Exception::OutOfMemory);
+		void getAtomForces(const System& system);
 
 		/** Set all Atom forces of a System to the values stored in this
 				instance of SnapShot.

--- a/include/BALL/MOLMEC/COMMON/snapShotManager.h
+++ b/include/BALL/MOLMEC/COMMON/snapShotManager.h
@@ -184,9 +184,9 @@ class BALL_EXPORT SnapShotManager
 			it in main memory. If there is not sufficient space, the snapshots
 			collected so far are flushed to hard disk. The first snapshot taken
 			has index 1.
-			@throw File::CannotWrite thrown if the snapshot could not be flushed to disk
+			@throw BALL::File::CannotWrite thrown if the snapshot could not be flushed to disk
 	*/
-	virtual void takeSnapShot() throw(File::CannotWrite);
+	virtual void takeSnapShot();
 
 	/** Read a certain SnapShot from a TrajectoryFile. This method tries to
 			read SnapShot number <b>number</b> from the file
@@ -217,8 +217,8 @@ class BALL_EXPORT SnapShotManager
 	virtual bool applyLastSnapShot();
 
 	/// This method writes all snapshots taken so far to hard disk
-	/// @throw File::CannotWrite thrown if the snapshots could not be flushed to disk
-	virtual void flushToDisk() throw(File::CannotWrite);
+	/// @throw BALL::File::CannotWrite thrown if the snapshots could not be flushed to disk
+	virtual void flushToDisk();
 
 	///
 	Size getNumberOfSnapShotsInBuffer() { return snapshot_buffer_.size(); }

--- a/include/BALL/MOLMEC/COMMON/support.h
+++ b/include/BALL/MOLMEC/COMMON/support.h
@@ -81,13 +81,13 @@ namespace BALL
 				@param	periodic_boundary_enabled flag indicating the use of periodic boundary conditions
 				@param	type	the type of algorithm used to calculate the pair vector
 				@return	the number of pairs generated (<tt>pair_vector.size()</tt>)
+				@throws BALL::Exception::OutOfMemory
 		*/
 		BALL_EXPORT BALL::Size calculateNonBondedAtomPairs
 			(ForceField::PairVector& pair_vector, 
 			 const AtomVector& atom_vector, const SimpleBox3& box, 
 			 double distance,	bool periodic_boundary_enabled, 
-			 PairListAlgorithmType type)
-			throw(Exception::OutOfMemory);
+			 PairListAlgorithmType type);
 
 		/**	Sort the pair list.
 				The atom pairs in the list ar sorted in such a way, that those atom pairs

--- a/include/BALL/MOLMEC/MMFF94/MMFF94.h
+++ b/include/BALL/MOLMEC/MMFF94/MMFF94.h
@@ -211,9 +211,9 @@ namespace BALL
 		//@{
 
 		/**	Force field specific setup
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool specificSetup()
-			throw(Exception::TooManyErrors);
+		virtual bool specificSetup();
 
 		//@}
 		/**	@name Accessors specific to the MMFF94 force field

--- a/include/BALL/MOLMEC/MMFF94/MMFF94NonBonded.h
+++ b/include/BALL/MOLMEC/MMFF94/MMFF94NonBonded.h
@@ -84,9 +84,10 @@ namespace BALL
 		bool operator == (const MMFF94NonBonded& anb)
 			;
 
-		///	Setup method.
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		/** Setup method.
+		 *  @throws BALL::Exception::TooManyErrors
+		 */
+		virtual bool setup();
 
 		///	Calculates and returns the component's energy.
 		virtual double updateEnergy()
@@ -100,9 +101,9 @@ namespace BALL
 				This method is called by the force field whenever
 				 \link ForceField::update ForceField::update \endlink  is called. It is used
 				to recalculate the nonbonded pair list.
+				@throws BALL::Exception::TooManyErrors
 		*/
-		virtual void update()
-			throw(Exception::TooManyErrors);
+		virtual void update();
 
 		///	Computes the most efficient way to calculate the non-bonded atom pairs
 		virtual MolmecSupport::PairListAlgorithmType

--- a/include/BALL/MOLMEC/MMFF94/MMFF94OutOfPlaneBend.h
+++ b/include/BALL/MOLMEC/MMFF94/MMFF94OutOfPlaneBend.h
@@ -54,9 +54,10 @@ namespace BALL
 		///	Destructor.
 		virtual ~MMFF94OutOfPlaneBend();
 
-		///	Setup method.
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		/** Setup method.
+		 *  @throws BALL::Exception::TooManyErrors
+		 */
+		virtual bool setup();
 
 		///	Calculates and returns the component's energy.
 		virtual double updateEnergy();

--- a/include/BALL/MOLMEC/MMFF94/MMFF94Parameters.h
+++ b/include/BALL/MOLMEC/MMFF94/MMFF94Parameters.h
@@ -59,9 +59,8 @@ namespace BALL
 		///
 		bool isInitialized() { return is_initialized_;}
 
-		///
-		bool readParameters(Parameters& p, const String& section)
-			throw(Exception::FileNotFound);
+		/// @throws BALL::Exception::FileNotFound
+		bool readParameters(Parameters& p, const String& section);
 
 		///
 		void setEquivalences(const MMFF94AtomTypeEquivalences& equi) { equiv_ = &equi;}
@@ -336,9 +335,10 @@ namespace BALL
 		bool assignParameters(Position stretch_bend_type, const Atom& atom1, const Atom& atom2, const Atom& atom3, 
 											 double& kba_ijk, double& kba_kji) const;
 
-		/// read parameters for stretch-bends and for assignment by periodic table row
-		bool readEmpiricalParameters(Parameters& p, const String& section)
-			throw(Exception::FileNotFound);
+		/** read parameters for stretch-bends and for assignment by periodic table row
+		 *  @throws BALL::Exception::FileNotFound
+		 */
+		bool readEmpiricalParameters(Parameters& p, const String& section);
 		
 		//@}
 
@@ -549,9 +549,8 @@ namespace BALL
 		*/
 		double getPartialCharge(Position at1, Position at2, Position bt) const;
 		
-		///
-		bool readEmpiricalParameters(Parameters& p, const String& section)
-			throw(Exception::FileNotFound);
+		/// @throws BALL::Exception::FileNotFound
+		bool readEmpiricalParameters(Parameters& p, const String& section);
 
 		///
 		double getPhi(Index atom_type) const;

--- a/include/BALL/MOLMEC/MMFF94/MMFF94StretchBend.h
+++ b/include/BALL/MOLMEC/MMFF94/MMFF94StretchBend.h
@@ -108,9 +108,9 @@ namespace BALL
 		virtual ~MMFF94StretchBend();
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		///	Calculates and returns the component's energy.
 		virtual double updateEnergy();

--- a/include/BALL/MOLMEC/MMFF94/MMFF94Torsion.h
+++ b/include/BALL/MOLMEC/MMFF94/MMFF94Torsion.h
@@ -82,9 +82,9 @@ namespace BALL
 		//@{
 
 		/**	Setup method.
+		 * @throws BALL::Exception::TooManyErrors
 		*/
-		virtual bool setup()
-			throw(Exception::TooManyErrors);
+		virtual bool setup();
 
 		//@}
 		/**	@name	Accessors	

--- a/include/BALL/NMR/createSpectrumProcessor.h
+++ b/include/BALL/NMR/createSpectrumProcessor.h
@@ -68,12 +68,11 @@ namespace BALL
 				Create a default instance of CreateSpectrumProcessor.
 				Calls  \link init init \endlink  to read default values from a configuration
 				file, see  \link init init \endlink  for details.
-				@exception FileNotFound if the INI file does not exist
-				@exception ParseError if the contents of the file could not be parsed
+				@exception BALL::Exception::FileNotFound if the INI file does not exist
+				@exception BALL::Exception::ParseError if the contents of the file could not be parsed
 		*/	
-		CreateSpectrumProcessor()
-			throw(Exception::FileNotFound, Exception::ParseError);
-		
+		CreateSpectrumProcessor();
+
 		/**	Destructor
 		*/
 		virtual ~CreateSpectrumProcessor();
@@ -88,8 +87,8 @@ namespace BALL
 				information on ignored and averaged atoms.
 				The default filename is <tt>NMR/StandardSpectrum.ini</tt> 
 				in the BALL data path.
-				@exception FileNotFound if the INI file does not exist
-				@exception ParseError if the contents of the file could not be parsed
+				@exception BALL::Exception::FileNotFound if the INI file does not exist
+				@exception BALL::Exception::ParseError if the contents of the file could not be parsed
 		*/
 		virtual void init();
 
@@ -98,11 +97,10 @@ namespace BALL
 				information on ignored and averaged atoms.
 				The default filename is <tt>NMR/StandardSpectrum.ini</tt> 
 				in the BALL data path.
-				@exception FileNotFound if the INI file does not exist
-				@exception ParseError if the contents of the file could not be parsed
+				@exception BALL::Exception::FileNotFound if the INI file does not exist
+				@exception BALL::Exception::ParseError if the contents of the file could not be parsed
 		*/
-		virtual void init(const String& filename)
-			throw(Exception::ParseError, Exception::FileNotFound);
+		virtual void init(const String& filename);
 
 		/**	Start method.
 		*/

--- a/include/BALL/NMR/empiricalHSShiftProcessor.h
+++ b/include/BALL/NMR/empiricalHSShiftProcessor.h
@@ -329,12 +329,12 @@ namespace BALL
 				 *  Note: 
 				 *  The spline or value can be accessed 
 				 *  by the {\tt operator () } given __not__ the property-value, but the property name. 
-				 *  
+				 *
+				 *  @throws BALL::Exception::FileNotFound
 				 */
 				ShiftHyperSurface_(String filename, String /* atomtype */,
 													 String firstproperty, String secondproperty, 
-													 int verbosity = EmpiricalHSShiftProcessor::VERBOSITY_LEVEL_CRITICAL)
-					throw(Exception::FileNotFound);  
+													 int verbosity = EmpiricalHSShiftProcessor::VERBOSITY_LEVEL_CRITICAL);
 
 				/**	Destructor.
 				*/

--- a/include/BALL/NMR/shiftModel.h
+++ b/include/BALL/NMR/shiftModel.h
@@ -106,18 +106,18 @@ namespace BALL
 		ModuleList& getModuleList();
 
 		/**	Set the parameter filename.
+		 * @throws BALL::Exception::FileNotFound
 		*/
-		void setFilename(const String& filename)
-			throw(Exception::FileNotFound);
+		void setFilename(const String& filename);
 
 		/**	Return the parameter filename.
 		*/
 		const String& getFilename() const;
 		
 		/**	Register a new module type.
+		 * @throws BALL::Exception::NullPointer
 		*/
-		void registerModule(const String& name, CreateMethod method) 
-			throw(Exception::NullPointer);
+		void registerModule(const String& name, CreateMethod method);
 
 		/**	Unregister a module type.
 		*/
@@ -182,9 +182,9 @@ namespace BALL
 				This method assumes that object has a valid	parameter file assigned.
 				It sets {\tt valid_} to <b>  true </b> if it could create a shift model 
 				from the contents of the parameter file.
+				@throws BALL::Exception::FileNotFound
 		*/
-		bool init_()
-			throw(Exception::FileNotFound);
+		bool init_();
 
 		/*_	Create a ShiftModule from a symbolic name.
 				This method create a shift module from the symbolic

--- a/include/BALL/NMR/shiftModel1D.h
+++ b/include/BALL/NMR/shiftModel1D.h
@@ -74,9 +74,9 @@ namespace BALL
 		//@{
 		
 		/**	Set the parameter filename.
+		 *  @throws BALL::Exception::FileNotFound
 		*/
-		void setFilename(const String& filename)
-			throw(Exception::FileNotFound);
+		void setFilename(const String& filename);
 
 		/**	Return the parameter filename.
 		*/
@@ -193,9 +193,9 @@ namespace BALL
 				This method assumes that object has a valid	parameter file assigned.
 				It sets {\tt valid_} to <b>  true </b> if it could create a shift model 
 				from the contents of the parameter file.
+				@throws BALL::Exception::FileNotFound
 		*/
-		bool init_()
-			throw(Exception::FileNotFound);
+		bool init_();
 
 		/*_ The spectrum peaks
 		 * */

--- a/include/BALL/NMR/shiftModel2D.h
+++ b/include/BALL/NMR/shiftModel2D.h
@@ -76,9 +76,9 @@ namespace BALL
 		//@{
 		
 		/**	Set the parameter filename.
+		 * @throws BALL::Exception::FileNotFound
 		*/
-		void setFilename(const String& filename)
-			throw(Exception::FileNotFound);
+		void setFilename(const String& filename);
 
 		/**	Return the parameter filename.
 		*/
@@ -195,9 +195,9 @@ namespace BALL
 				This method assumes that object has a valid	parameter file assigned.
 				It sets {\tt valid_} to <b>  true </b> if it could create a shift model 
 				from the contents of the parameter file.
+				@throws BALL::Exception::FileNotFound
 		*/
-		bool init_()
-			throw(Exception::FileNotFound);
+		bool init_();
 		
 		void createPeak_(Atom* proton, Atom* atom, float peakwidth_proton, float peakwidth_atom);
 		/*_ The spectrum peaks

--- a/include/BALL/SCORING/COMPONENTS/PLP.h
+++ b/include/BALL/SCORING/COMPONENTS/PLP.h
@@ -99,11 +99,12 @@ namespace BALL
 			virtual void updateForces() throw();
 
 			/**	Update the pair list.
-			This method is called by the force field whenever
-			\link ForceField::update ForceField::update \endlink  is called. It is used
-			to recalculate the nonbonded pair list. */
-			virtual void update()
-				throw(Exception::TooManyErrors);
+					This method is called by the force field whenever
+					\link ForceField::update ForceField::update \endlink  is called. It is used
+					to recalculate the nonbonded pair list.
+					@throws BALL::Exception::TooManyErrors
+			 */
+			virtual void update();
 
 			double getVDWEnergy() const;
 

--- a/include/BALL/SCORING/FUNCTIONS/forceFieldEvaluation.h
+++ b/include/BALL/SCORING/FUNCTIONS/forceFieldEvaluation.h
@@ -60,9 +60,8 @@ namespace BALL
 				const Options& getOptions() const
 					throw();
 
-				///
-				virtual std::vector < ConformationSet::Conformation > operator () (ConformationSet& conformations)
-					throw(Exception::TooManyErrors);
+				/// @throws BALL::Exception::TooManyErrors
+				virtual std::vector < ConformationSet::Conformation > operator () (ConformationSet& conformations);
 
 			protected:
 

--- a/include/BALL/SOLVATION/electrostaticPotentialCalculator.h
+++ b/include/BALL/SOLVATION/electrostaticPotentialCalculator.h
@@ -83,9 +83,9 @@ namespace BALL
 		
 		/** Apply the current model to the System S and prepare everything for a calculation.
 		 		@exception NullPointer if FragmentDB is not set
+		 		@throws BALL::Exception::NullPointer
 		 */
-		void apply(System &S)
-			throw(Exception::NullPointer);
+		void apply(System &S);
 
 		///
 		void setFragmentDB(const FragmentDB* db)

--- a/include/BALL/SOLVATION/generalizedBornCase.h
+++ b/include/BALL/SOLVATION/generalizedBornCase.h
@@ -116,9 +116,8 @@ namespace BALL
 			static const String FILENAME;
 		};
 
-		///
-		GeneralizedBornModel()
-			throw(Exception::FileNotFound);
+		/// @throws BALL::Exception::FileNotFound
+		GeneralizedBornModel();
 
 		///
 		~GeneralizedBornModel();
@@ -126,9 +125,10 @@ namespace BALL
 		///
 		void clear();
 
-		/// We need an additional optioned version of that piece of code
-		bool setup(const AtomContainer& ac)
-			throw(Exception::FileNotFound);
+		/** We need an additional optioned version of that piece of code
+		    @throws BALL::Exception::FileNotFound
+		 */
+		bool setup(const AtomContainer& ac);
 
 		/// ??? This should be done through Options!
 		void setScalingFactorFile(const String& filename);
@@ -161,9 +161,8 @@ namespace BALL
 		/// system at the position of atom_i
 		float calculatePotential(const Atom& atom_i) const;
 
-		///
-		bool readScalingFactors(const String& inifile_name)
-			throw(Exception::FileNotFound);
+		/// @throws BALL::Exception::FileNotFound
+		bool readScalingFactors(const String& inifile_name);
 
 
 		private:

--- a/include/BALL/SOLVATION/pair6_12InteractionEnergyProcessor.h
+++ b/include/BALL/SOLVATION/pair6_12InteractionEnergyProcessor.h
@@ -252,10 +252,8 @@ namespace BALL
 		*/
 		//@{
 
-		/** 
-		*/
-		virtual bool finish() 
-			throw(Exception::DivisionByZero);
+		/// @throws BALL::Exception::DivisionByZero
+		virtual bool finish();
 
 		//@}
 		/** @name Options 

--- a/include/BALL/SOLVATION/solventDescriptor.h
+++ b/include/BALL/SOLVATION/solventDescriptor.h
@@ -138,15 +138,15 @@ namespace BALL
 		*/
 		Size getNumberOfAtomTypes() const;
 
-		/** Get atom decriptions by index 
+		/** Get atom decriptions by index
+		    @throws BALL::Exception::IndexOverflow
 		*/
-		const SolventAtomDescriptor& getAtomDescriptor(Position index) const 
-			throw(Exception::IndexOverflow);
+		const SolventAtomDescriptor& getAtomDescriptor(Position index) const;
 		
 		/** Get atom decriptions by index 
+		    @throws BALL::Exception::IndexOverflow
 		*/
-		SolventAtomDescriptor& getAtomDescriptor(Position index) 
-			throw(Exception::IndexOverflow);
+		SolventAtomDescriptor& getAtomDescriptor(Position index);
 
 		//@}
 		/** @name Predicates 

--- a/include/BALL/STRUCTURE/RMSDMinimizer.h
+++ b/include/BALL/STRUCTURE/RMSDMinimizer.h
@@ -46,15 +46,23 @@ namespace BALL
 		typedef std::vector<Vector3> PointVector;
 		typedef std::pair<Matrix4x4, double> Result;
 
-		static Result computeTransformation(const AtomBijection& ab)
-			throw(RMSDMinimizer::IncompatibleCoordinateSets, RMSDMinimizer::TooFewCoordinates);
+		/**
+		 * @throws BALL::RMSDMinimizer::IncompatibleCoordinateSets
+		 * @throws BALL::RMSDMinimizer::TooFewCoordinates
+		 */
+		static Result computeTransformation(const AtomBijection& ab);
 
-		static Result computeTransformation(const PointVector& X, const PointVector& Y)
-			throw(RMSDMinimizer::IncompatibleCoordinateSets, RMSDMinimizer::TooFewCoordinates);
+		/**
+		 * @throws BALL::RMSDMinimizer::IncompatibleCoordinateSets
+		 * @throws BALL::RMSDMinimizer::TooFewCoordinates
+		 */
+		static Result computeTransformation(const PointVector& X, const PointVector& Y);
 
-		static double minimizeRMSD(AtomContainer& a, AtomContainer& b)
-			throw(RMSDMinimizer::IncompatibleCoordinateSets, RMSDMinimizer::TooFewCoordinates);
-
+		/**
+		 * @throws BALL::RMSDMinimizer::IncompatibleCoordinateSets
+		 * @throws BALL::RMSDMinimizer::TooFewCoordinates
+		 */
+		static double minimizeRMSD(AtomContainer& a, AtomContainer& b);
  };
 
 }	// namespace BALL

--- a/include/BALL/STRUCTURE/RSEdge.h
+++ b/include/BALL/STRUCTURE/RSEdge.h
@@ -296,9 +296,9 @@ namespace BALL
 				@return	TVector3<double>	the intersection point near to the first
 														RSVertex if i = 0, the intersection point near
 														to the second RSVertex otherwise
+				@throws BALL::Exception::GeneralException
 		*/
-		TVector3<double> getIntersectionPoint(Position i) const
-			throw(Exception::GeneralException);
+		TVector3<double> getIntersectionPoint(Position i) const;
 
 		/** Set singular
 		*/

--- a/include/BALL/STRUCTURE/RSFace.h
+++ b/include/BALL/STRUCTURE/RSFace.h
@@ -116,6 +116,7 @@ namespace BALL
 				@param	normal		assigned to the normal vector
 				@param	singular
 				@param	index			assigned to the index
+				@throws BALL::Exception::DivisionByZero
 		*/
 		RSFace(RSVertex* vertex1,
 				RSVertex* vertex2,
@@ -126,8 +127,7 @@ namespace BALL
 				const TVector3<double>& center,
 				const TVector3<double>& normal,
 				bool singular,
-				Index index)
-			throw(Exception::DivisionByZero);
+				Index index);
 
 		/**	Destructor.
 				Destructs the RSFace object.
@@ -168,6 +168,7 @@ namespace BALL
 				@param	normal		assigned to the normal vector
 				@param	singular
 				@param	index			assigned to the index
+				@throws BALL::Exception::DivisionByZero
 		*/
 		void set(RSVertex* vertex1,
 				RSVertex* vertex2,
@@ -178,8 +179,7 @@ namespace BALL
 				const TVector3<double>& center,
 				const TVector3<double>& normal,
 				bool singular,
-				Index index)
-			throw(Exception::DivisionByZero);
+				Index index);
 
 		//@}
 		/**	@name	Predicates
@@ -233,9 +233,9 @@ namespace BALL
 
 		/** Set the vector orthogonal to the RSFace.
 				@param	normal	the new normal
+				@throws BALL::Exception::DivisionByZero
 		*/
-		void setNormal(const TVector3<double>& normal)
-			throw(Exception::DivisionByZero);
+		void setNormal(const TVector3<double>& normal);
 
 		/** Return the vector orthogonal to the RSFace.
 				@return	TVector3<double>	the vector orthogonal to the RSFace.

--- a/include/BALL/STRUCTURE/SESVertex.h
+++ b/include/BALL/STRUCTURE/SESVertex.h
@@ -140,9 +140,9 @@ namespace BALL
 
 		/**	Set the normal vector of the SESVertex.
 				@param	normal	the new normal vector
+				@throws BALL::Exception::DivisionByZero
 		*/
-		void setNormal(const TVector3<double>& normal)
-			throw(Exception::DivisionByZero);
+		void setNormal(const TVector3<double>& normal);
 
 		/**	Return the normal vector of the SESVertex.
 				@return	TVector3<double>	the normal vector of the vertex

--- a/include/BALL/STRUCTURE/assignBondOrderProcessor.h
+++ b/include/BALL/STRUCTURE/assignBondOrderProcessor.h
@@ -307,7 +307,7 @@ namespace BALL
 			AssignBondOrderProcessor();
 
 			// constructor with parameter filename //TODO
-			//AssignBondOrderProcessor(const String& file_name) throw(Exception::FileNotFound);
+			//AssignBondOrderProcessor(const String& file_name);
 
 			/// Destructor
 			virtual ~AssignBondOrderProcessor();
@@ -401,8 +401,9 @@ namespace BALL
 			 *  @param  i index of the solution, whose bond order assignment should be applied. 
 			 * 	@return const System& - the original system with bond order assignment of solution i. 
 			 * 					If i is invalid, an Exception is thrown.
+			 * 	@throws BALL::Exception::IndexOverflow
 			 */
-			const System& getSolution(Position i) throw(Exception::IndexOverflow);
+			const System& getSolution(Position i);
 
 			/** Returns the total charge of solution i. 
 			 
@@ -544,8 +545,9 @@ namespace BALL
 			/** Reads and stores the penalty-INIFile (for example BondOrder.ini).
 			 *
 			 *	@return bool - false if the INIFile could not be read correctly.
+			 *	@throws BALL::Exception::FileNotFound
 			 */
-			bool readAtomPenalties_() throw(Exception::FileNotFound());
+			bool readAtomPenalties_();
 
 			/** Assigns every atom of the AtomContainer to which the
 			 *  processor is applied to a block of possible valences 

--- a/include/BALL/STRUCTURE/buildBondsProcessor.h
+++ b/include/BALL/STRUCTURE/buildBondsProcessor.h
@@ -101,8 +101,10 @@ namespace BALL
 			/// copy construcor
 			BuildBondsProcessor(const BuildBondsProcessor& bbp);
 		
-			/// constructor with parameter filename
-			BuildBondsProcessor(const String& file_name) throw(Exception::FileNotFound);
+			/** constructor with parameter filename
+			 *  @throws BALL::Exception::FileNotFound
+			 */
+			BuildBondsProcessor(const String& file_name);
 			
 			/// destructor
 			virtual ~BuildBondsProcessor();
@@ -125,8 +127,10 @@ namespace BALL
 			/// Return the number of bonds built during the last application.
 			Size getNumberOfBondsBuilt();
 
-			/// sets the parameters file
-			void setBondLengths(const String& file_name) throw(Exception::FileNotFound);
+			/** sets the parameters file
+			 *  @throws BALL::Exception::FileNotFound
+			 */
+			void setBondLengths(const String& file_name);
 
 			/// Return the bond length Hashmap 
 			HashMap<Size, HashMap<Size, HashMap<int, float> > > getBondMap() { return bond_lengths_;};
@@ -165,8 +169,10 @@ namespace BALL
 			/// deletes bonds, like from multiple bonded hydrogens or halogens
 			void deleteOverestimatedBonds_(AtomContainer& ac);
 			
-			/// method to read the paramter file
-			void readBondLengthsFromFile_(const String& file_name = "") throw(Exception::FileNotFound);
+			/** method to read the paramter file
+			 *  @throws BALL::Exception::FileNotFound
+			 */
+			void readBondLengthsFromFile_(const String& file_name = "");
 			
 			/// number of bonds, which are created during the processor call
 			Size num_bonds_;

--- a/include/BALL/STRUCTURE/defaultProcessors.h
+++ b/include/BALL/STRUCTURE/defaultProcessors.h
@@ -68,10 +68,9 @@ namespace BALL
 		AssignRadiusProcessor();
 
 		/** Detailled constructor.
-				If the file can not be found in the actual path, FileNotFound is thrown.
+		 *  @throws BALL::Exception::FileNotFound if the file can not be found in the actual path.
 		*/
-		AssignRadiusProcessor(const String& filename)
-			throw(Exception::FileNotFound);
+		AssignRadiusProcessor(const String& filename);
 
 		/** Start Method.
 		 * 	The number of errors and the numbers of assignments are reset to 0.
@@ -103,10 +102,9 @@ namespace BALL
 		virtual Processor::Result operator()(Atom& atom);
 
 		/**	Set the filename to read the radii from.
-		 *  If the file can not be found in the actual path, FileNotFound is thrown.
+		 *  @throws BALL::Exception::FileNotFound if the file can not be found in the actual path.
 		 */
-		void setFilename(const String& filename)
-			throw(Exception::FileNotFound);
+		void setFilename(const String& filename);
 
 		/**	Return the current filename
 		*/
@@ -125,9 +123,10 @@ namespace BALL
 
 		protected:
 
-		//_ Extract the data from the file.
-		bool buildTable_()
-			throw(Exception::FileNotFound);
+		/** Extract the data from the file.
+		 *  @throws BALL::Exception::FileNotFound
+		 */
+		bool buildTable_();
 
 		String									filename_;
 		StringHashMap<float>		table_;
@@ -151,10 +150,9 @@ namespace BALL
 		AssignChargeProcessor();
 
 		/** Detailled constructor.
-		 * 	If the file can not be found in the actual path, FileNotFound is thrown.
+		 *  @throws BALL::Exception::FileNotFound if the file can not be found in the actual path.
 		 */
-		AssignChargeProcessor(const String& filename)
-			throw(Exception::FileNotFound);
+		AssignChargeProcessor(const String& filename);
 		
     /** Start Method.
 		 *  The number of errors and the numbers of assignments are reset to 0.

--- a/include/BALL/STRUCTURE/geometricProperties.h
+++ b/include/BALL/STRUCTURE/geometricProperties.h
@@ -304,9 +304,9 @@ namespace BALL
 	//@{
 		
 	/**	Calculate the torsion angle between four atoms
+	    @throws BALL::Exception::IllegalPosition
 	*/
-	BALL_EXPORT Angle calculateTorsionAngle(const Atom& a1, const Atom& a2, const Atom& a3, const Atom& a4)
-		throw(Exception::IllegalPosition);
+	BALL_EXPORT Angle calculateTorsionAngle(const Atom& a1, const Atom& a2, const Atom& a3, const Atom& a4);
 
 	/**
 	 * Set the torsion angle defined by a1, a2, a3, a4. The atoms should be connected by bonds
@@ -319,9 +319,9 @@ namespace BALL
 	BALL_EXPORT bool setTorsionAngle(const Atom& a1, const Atom& a2, Atom& a3, const Atom& a4, Angle angle);
 
 	/**	Calculate the bond angle between three atoms
+	    @throws BALL::Exception::IllegalPosition
 	*/
-	BALL_EXPORT Angle calculateBondAngle(const Atom& a1, const Atom& a2, const Atom& a3)
-		throw(Exception::IllegalPosition);
+	BALL_EXPORT Angle calculateBondAngle(const Atom& a1, const Atom& a2, const Atom& a3);
 
 	//@}
 } // namespace BALL

--- a/include/BALL/STRUCTURE/graphEdge.h
+++ b/include/BALL/STRUCTURE/graphEdge.h
@@ -163,18 +163,18 @@ namespace BALL
 				thrown.
 				@param	vertex	one of the vertices of the GraphEdge
 				@return	Vertex*	the other vertex
+				@throws BALL::Exception::GeneralException
 		*/
-		Vertex* other(const Vertex* vertex) const
-			throw(Exception::GeneralException);
+		Vertex* other(const Vertex* vertex) const;
 
 		/** Return a pointer to the other face of the GraphEdge.
 				If the given face is not neighboured to the GraphEdge, an exception is
 				thrown.
 				@param	face	one of the faces of the GraphEdge
 				@return	Face*	the other face
+				@throws BALL::Exception::GeneralException
 		*/
-		Face* other(const Face* face) const
-			throw(Exception::GeneralException);
+		Face* other(const Face* face) const;
 
 		/** Substitute a vertex by an other one.
 				@param	old_vertex	the vertex that has to be substituted
@@ -435,7 +435,6 @@ namespace BALL
 
 	template <typename Vertex, typename Edge, typename Face>
 	Vertex* GraphEdge<Vertex,Edge,Face>::other(const Vertex* vertex) const
-		throw(Exception::GeneralException)
 	{
 		if (vertex_[0] == vertex)
 		{
@@ -457,7 +456,6 @@ namespace BALL
 
 	template <typename Vertex, typename Edge, typename Face>
 	Face* GraphEdge<Vertex,Edge,Face>::other(const Face* face) const
-		throw(Exception::GeneralException)
 	{
 		if (face_[0] == face)
 		{

--- a/include/BALL/STRUCTURE/graphFace.h
+++ b/include/BALL/STRUCTURE/graphFace.h
@@ -720,34 +720,34 @@ namespace BALL
 				@param	i				the relative index of the vertex which should be set.
 												If i is greater three, an exception is thrown.
 				@param	vertex	a pointer to the new vertex
+				@throws BALL::Exception::IndexOverflow
 		*/
-		void setVertex(Position i, Vertex* vertex)
-			throw(Exception::IndexOverflow);
+		void setVertex(Position i, Vertex* vertex);
 
 		/** Return one of the vertices of the GraphTriangle.
 				@param	i				the relative index of the vertex which should be given
 												back. If i is greater than three, an exception is
 												thrown.
 				@return	Vertex*	a pointer to the asked vertex
+				@throws BALL::Exception::IndexOverflow
 		*/
-		Vertex* getVertex(Position i) const
-			throw(Exception::IndexOverflow);
+		Vertex* getVertex(Position i) const;
 
 		/** Set one of the edges of the GraphTriangle.
 				@param	i			the relative index of the edge which should be set.
 											If i is greater than three, an exception is thrown.
 				@param	edge	a pointer to the new edge
+				@throws BALL::Exception::IndexOverflow
 		*/
-		void setEdge(Position i, Edge* edge)
-			throw(Exception::IndexOverflow);
+		void setEdge(Position i, Edge* edge);
 
 		/** Return one of the edges of the GraphTriangle.
 				@param	i			the relative index of the edge which should be given
 											back. If i is greater than three, an exception is thrown.
 				@return	Edge*	a pointer to the asked vertex
+				@throws BALL::Exception::IndexOverflow
 		*/
-		Edge* getEdge(Position i) const
-			throw(Exception::IndexOverflow);
+		Edge* getEdge(Position i) const;
 
 		/** Set the index of the GraphTriangle.
 				@param	index	the new index
@@ -1023,7 +1023,6 @@ namespace BALL
 
 	template <typename Vertex, typename Edge, typename Face>
 	void GraphTriangle<Vertex,Edge,Face>::setVertex(Position i, Vertex* vertex)
-		throw(Exception::IndexOverflow)
 	{
 		if (i > 2)
 		{
@@ -1038,7 +1037,6 @@ namespace BALL
 
 	template <typename Vertex, typename Edge, typename Face>
 	Vertex* GraphTriangle<Vertex,Edge,Face>::getVertex(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i > 2)
 		{
@@ -1053,7 +1051,6 @@ namespace BALL
 
 	template <typename Vertex, typename Edge, typename Face>
 	void GraphTriangle<Vertex,Edge,Face>::setEdge(Position i, Edge* edge)
-		throw(Exception::IndexOverflow)
 	{
 		if (i > 2)
 		{
@@ -1068,7 +1065,6 @@ namespace BALL
 
 	template <typename Vertex, typename Edge, typename Face>
 	Edge* GraphTriangle<Vertex,Edge,Face>::getEdge(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i > 2)
 		{

--- a/include/BALL/STRUCTURE/hybridisationProcessor.h
+++ b/include/BALL/STRUCTURE/hybridisationProcessor.h
@@ -114,9 +114,11 @@ namespace BALL
 			/// copy construcor
 			HybridisationProcessor(const HybridisationProcessor& hp);
 		
-			/// Constructor with parameter filename for the smarts based algorithm
-			/// and parameter filename for the force field based method
-			HybridisationProcessor(const String& smarts_file_name, const String& ff_file_name) throw(Exception::FileNotFound);
+			/** Constructor with parameter filename for the smarts based algorithm
+					and parameter filename for the force field based method
+					@throws BALL::Exception::FileNotFound
+			 */
+			HybridisationProcessor(const String& smarts_file_name, const String& ff_file_name);
 			
 			/// destructor
 			virtual ~HybridisationProcessor();
@@ -139,8 +141,10 @@ namespace BALL
 			/// Return the number of hybridisation states set during the last application.
 			Size getNumberOfHybridisationStatesSet(); 
 
-			/// sets the parameters file
-			void setAtomTypeSmarts(const String& file_name) throw(Exception::FileNotFound);
+			/** sets the parameters file
+				@throws BALL::Exception::FileNotFound
+			 */
+			void setAtomTypeSmarts(const String& file_name);
 
 			/// Return the atom_types--hybridisation  Hashmap 
 			vector< std::pair<String, Size> > getHybridisationMap() { return atom_type_smarts_;};
@@ -188,8 +192,10 @@ namespace BALL
 				String a3;
 			};
 			
-			/// method to read the paramter file
-			bool readAtomTypeSmartsFromFile_(const String& file_name = "") throw(Exception::FileNotFound);
+			/** method to read the paramter file
+					@throws BALL::Exception::FileNotFound
+			 */
+			bool readAtomTypeSmartsFromFile_(const String& file_name = "");
 			
 			/// number of bonds, which are created during the processor call
 			Size num_hybridisation_states_;
@@ -201,8 +207,9 @@ namespace BALL
 			 *  are stored in 'rad'.
 			 */
 			StringHashMap<StringHashMap<StringHashMap<std::multimap<float, AtomNames_> > > > bond_angles_;
-			
-			bool readAndInitBondAnglesFromFile_(const String& file_name = "") throw(Exception::FileNotFound);
+
+			/// @throws BALL::Exception::FileNotFound
+			bool readAndInitBondAnglesFromFile_(const String& file_name = "");
 			
 			/** Maps the atom types onto their elements
 			 */

--- a/include/BALL/STRUCTURE/peptides.h
+++ b/include/BALL/STRUCTURE/peptides.h
@@ -251,14 +251,14 @@ namespace BALL
 			protected:	
 				
 				/** Read the Conversion table from file.
+				 *  @throws BALL::Exception::FileNotFound
 				 */
-				void readConversionTable_()
-					throw (Exception::FileNotFound());
+				void readConversionTable_();
 			
 				/** Read the pseudo atoms conversion table from file.
+				 *  @throws BALL::Exception::FileNotFound
 				 */
-				void readPseudoAtomsConversionTable_()
-					throw (Exception::FileNotFound());
+				void readPseudoAtomsConversionTable_();
 
 				std::vector<String> 								conventions_;
 				std::vector< std::vector <String> > conversion_table_;	

--- a/include/BALL/STRUCTURE/reducedSurface.h
+++ b/include/BALL/STRUCTURE/reducedSurface.h
@@ -301,30 +301,30 @@ namespace BALL
 		/** Return the i'th sphere.
 				@param	i	the index of the sphere that should be given back
 				@return TSphere3<double>, the i'th sphere
+				@throws BALL::Exception::IndexOverflow
 		*/
-    TSphere3<double> getSphere(Position i) const
-	    throw(Exception::IndexOverflow);
+    TSphere3<double> getSphere(Position i) const;
 
 		/** Return the i'th rsvertex.
 				@param	i	the index of the rsvertex that should be given back
 				@return RSVertex, the i'th rsvertex
+				@throws BALL::Exception::IndexOverflow
 		*/
-		RSVertex* getVertex(Position i) const
-			throw(Exception::IndexOverflow);
+		RSVertex* getVertex(Position i) const;
 
 		/** Return the i'th rsedge.
 				@param	i	the index of the rsedge that should be given back
 				@return RSEdge, the i'th rsedge
+				@throws BALL::Exception::IndexOverflow
 		*/
-		RSEdge* getEdge(Position i) const
-			throw(Exception::IndexOverflow);
+		RSEdge* getEdge(Position i) const;
 
 		/** Return the i'th rsface.
 				@param	i	the index of the rsface that should be given back
 				@return RSFace, the i'th rsface
+				@throws BALL::Exception::IndexOverflow
 		*/
-		RSFace* getFace(Position i) const
-			throw(Exception::IndexOverflow);
+		RSFace* getFace(Position i) const;
 
 		/** Insert a new RSVertex.
 				@param	rsvertex	a pointer to the RSVertex to insert
@@ -628,9 +628,9 @@ namespace BALL
 												1, if a single vertex is found,
 												2, if an edge is found,
 												3, if a face is found
+			@throws BALL::Exception::DivisionByZero
 		*/
-		Position getStartPosition()
-			throw(Exception::DivisionByZero);
+		Position getStartPosition();
 
 		//@}
 		/*_ @name Finding a first face
@@ -640,9 +640,9 @@ namespace BALL
 		/*_ Try to find a starting face
 			@return	RSFace*	a pointer to the found face, if a face can be found,
 													NULL otherwise
+			@throws BALL::Exception::DivisionByZero
 		*/
-		RSFace* findFirstFace()
-			throw(Exception::DivisionByZero);
+		RSFace* findFirstFace();
 
 		/*_ Try to find a starting face in a given direction
 			@param	direction		search in x-direction, if direction is 0,
@@ -652,9 +652,9 @@ namespace BALL
 													search in max direction, if extrem is 1
 			@return	RSFace*	a pointer to the found face, if a face can be found,
 													NULL otherwise
+			@throws BALL::Exception::DivisionByZero
 		*/
-		RSFace* findFace(Position direction, Position extrem)
-			throw(Exception::DivisionByZero);
+		RSFace* findFace(Position direction, Position extrem);
 
 		//@}
 		/*_ @name Finding a first edge

--- a/include/BALL/STRUCTURE/residueRotamerSet.h
+++ b/include/BALL/STRUCTURE/residueRotamerSet.h
@@ -181,12 +181,15 @@ namespace BALL
 		Size getNumberOfTorsions() const;
 
 		/**	Set the number of valid torsions for this side chain.
-				\exception Exception::IndexOverflow if the number of torsions is above four.
+				\exception BALL::Exception::IndexOverflow if the number of torsions is above four.
 		*/
-		void setNumberOfTorsions(Size number_of_torsions) throw(Exception::IndexOverflow);
+		void setNumberOfTorsions(Size number_of_torsions);
 
-		///	Random access operator for single rotamers.
-		const Rotamer& operator [] (Position index)	const throw(Exception::IndexOverflow);
+		/** Random access operator for single rotamers.
+				\exception BALL::Exception::IndexOverflow
+		 */
+
+		const Rotamer& operator [] (Position index)	const;
 
 		/// 
 		bool hasTorsionPhi() const;

--- a/include/BALL/STRUCTURE/smartsParser.h
+++ b/include/BALL/STRUCTURE/smartsParser.h
@@ -647,9 +647,9 @@ namespace BALL
 		*/
 		//@{
 		/**	Parse a SMARTS string.
+		 *  @throws BALL::Exception::ParseError
 		*/
-		void parse(const String& s)
-			throw(Exception::ParseError);
+		void parse(const String& s);
 
 		/**	@name Accessors
 		*/

--- a/include/BALL/STRUCTURE/smilesParser.h
+++ b/include/BALL/STRUCTURE/smilesParser.h
@@ -129,9 +129,9 @@ namespace BALL
 		*/
 		//@{
 		/**	Parse a SMILES string.
+		    @throws BALL::Exception::ParserError
 		*/
-		void parse(const String& s)
-			throw(Exception::ParseError);
+		void parse(const String& s);
 
 		/**	Return the parsed system
 		*/

--- a/include/BALL/STRUCTURE/solventAccessibleSurface.h
+++ b/include/BALL/STRUCTURE/solventAccessibleSurface.h
@@ -81,42 +81,42 @@ namespace BALL
 		//@{
 		
 		/**
+		 * @throws BALL::Exception::IndexOverflow
 		*/
-		void setVertex(SASVertex* vertex, Position i)
-			throw(Exception::IndexOverflow);
+		void setVertex(SASVertex* vertex, Position i);
 
 		/**
+		 * @throws BALL::Exception::IndexOverflow
 		*/
-		SASVertex* getVertex(Position i) const
-			throw(Exception::IndexOverflow);
+		SASVertex* getVertex(Position i) const;
 
 		/**
 		*/
 		Size numberOfVertices() const;
 		
 		/**
+		 * @throws BALL::Exception::IndexOverflow
 		*/
-		void setEdge(SASEdge* edge, Position i)
-			throw(Exception::IndexOverflow);
+		void setEdge(SASEdge* edge, Position i);
 
 		/**
+		 * @throws BALL::Exception::IndexOverflow
 		*/
-		SASEdge* getEdge(Position i) const
-			throw(Exception::IndexOverflow);
+		SASEdge* getEdge(Position i) const;
 
 		/**
 		*/
 		Size numberOfEdges() const;
 		
 		/**
+		 * @throws BALL::Exception::IndexOverflow
 		*/
-		void setFace(SASFace* face, Position i)
-			throw(Exception::IndexOverflow);
+		void setFace(SASFace* face, Position i);
 
 		/**
+		 * @throws BALL::Exception::IndexOverflow
 		*/
-		SASFace* getFace(Position i) const
-			throw(Exception::IndexOverflow);
+		SASFace* getFace(Position i) const;
 
 		/**
 		*/

--- a/include/BALL/STRUCTURE/solventExcludedSurface.h
+++ b/include/BALL/STRUCTURE/solventExcludedSurface.h
@@ -149,9 +149,9 @@ namespace BALL
 		void clean(const double& density);
 
 		/**	Computes the solvent excluded surface from a ReducedSurface object
+		 * @throws BALL::Exception::GeneralException
 		*/
-		void compute()
-			throw(Exception::GeneralException);
+		void compute();
 
 		void splitSphericFaces()
 			;
@@ -347,9 +347,9 @@ namespace BALL
 		//@{
 
 		/**	Computes the solvent excluded surface
+		 * @throws BALL::Exception::GeneralException
 		*/
-		void run()
-			throw(Exception::GeneralException);
+		void run();
 
 		//@}
 
@@ -497,9 +497,9 @@ namespace BALL
 		//@{
 
 		/**	Solves the singularities
+				@throws BALL::Exception::GeneralException
 		*/
-		bool run()
-			throw(Exception::GeneralException);
+		bool run();
 
 		//@}
 

--- a/include/BALL/STRUCTURE/surfaceProcessor.h
+++ b/include/BALL/STRUCTURE/surfaceProcessor.h
@@ -96,9 +96,10 @@ namespace BALL
 		/**
 		 * Sets the radius of the used probe sphere
 		 *
-		 * @throw Exception::OutOfRange Specifying a radius <= 0 is illegal
+		 * @throw BALL::Exception::OutOfRange Specifying a radius <= 0 is illegal
 		 */
-		void setProbeRadius(double radius) throw(Exception::OutOfRange){
+		void setProbeRadius(double radius)
+		{
 			if(radius <= 0.0) {
 				throw Exception::OutOfRange(__FILE__, __LINE__);
 			}

--- a/include/BALL/STRUCTURE/triangle.h
+++ b/include/BALL/STRUCTURE/triangle.h
@@ -132,18 +132,18 @@ namespace BALL
 				@param	i			the relative index of the point which should be set.	
 											If i is greater three, an exception is thrown.
 				@param	point	a pointer to the new point
+				@throws BALL::Exception::IndexOverflow
 		*/
-		void setPoint(Position i, TrianglePoint* point)
-			throw(Exception::IndexOverflow);
+		void setPoint(Position i, TrianglePoint* point);
 
 		/** Return one of the three points of the Triangle.
 				@param	i										the relative index of the point which	
 																		should be given back. If i is greater	
 																		three, an exception is thrown.
 				@return	TrianglePoint*	a pointer to the asked point
+				@throws BALL::Exception::IndexOverflow
 		*/
-		TrianglePoint* getPoint(Position i) const
-			throw(Exception::IndexOverflow);
+		TrianglePoint* getPoint(Position i) const;
 
 		/**	Remove an edge from the Triangle.
 				The edge is set to NULL.

--- a/include/BALL/STRUCTURE/trianglePoint.h
+++ b/include/BALL/STRUCTURE/trianglePoint.h
@@ -143,9 +143,9 @@ namespace BALL
 			;
 
 		/** Set the normal of the TrianglePoint
+		    @throws BALL::Exception::DivisionByZero
 		*/
-		void setNormal(const TVector3<double>& normal)
-			throw(Exception::DivisionByZero);
+		void setNormal(const TVector3<double>& normal);
 
 		//@}
 

--- a/include/BALL/STRUCTURE/triangulatedSES.h
+++ b/include/BALL/STRUCTURE/triangulatedSES.h
@@ -131,8 +131,10 @@ namespace BALL
 		*/
 		//@{
 
-		void compute()
-			throw(Exception::GeneralException,Exception::DivisionByZero);
+		/** @throws BALL::Exception::GeneralException
+		    @throws BALL::Exception::DivisionByZero
+		 */
+		void compute();
 
 		//@}
 
@@ -192,8 +194,10 @@ namespace BALL
 		*/
 		//@{
 
-		void run()
-			throw(Exception::GeneralException,Exception::DivisionByZero);
+		/** @throws BALL::Exception::GeneralException
+		    @throws BALL::Exception::DivisionByZero
+		 */
+		void run();
 
 		private:
 

--- a/include/BALL/VIEW/DIALOGS/MMFF94ConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/MMFF94ConfigurationDialog.h
@@ -69,8 +69,9 @@ namespace BALL
 
 			private:
 			String getValue_(const QCheckBox* box) const;
-			float getValue_(const QLineEdit* edit) const
-				throw(Exception::InvalidFormat);
+
+			/// @throws BALL::Exception::InvalidFormat
+			float getValue_(const QLineEdit* edit) const;
 
 			MMFF94* mmff_;
 		};

--- a/include/BALL/VIEW/DIALOGS/amberConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/amberConfigurationDialog.h
@@ -74,8 +74,8 @@ namespace BALL
 
 			String getValue_(const QCheckBox* box) const;
 
-			float getValue_(const QLineEdit* edit) const
-				throw(Exception::InvalidFormat);
+			/// @throws BALL::Exception::InvalidFormat
+			float getValue_(const QLineEdit* edit) const;
 
 			AmberFF* amber_;
 		};

--- a/include/BALL/VIEW/DIALOGS/assignBondOrderConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/assignBondOrderConfigurationDialog.h
@@ -82,8 +82,8 @@ namespace BALL
 
 				String getValue_(const QCheckBox* box) const;
 
-				float getValue_(const QLineEdit* edit) const
-					throw(Exception::InvalidFormat);
+				/// @throws BALL::Exception::InvalidFormat
+				float getValue_(const QLineEdit* edit) const;
 		};
 	}
 }

--- a/include/BALL/VIEW/DIALOGS/charmmConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/charmmConfigurationDialog.h
@@ -77,8 +77,8 @@ namespace BALL
 
 			String getValue_(const QCheckBox* box) const;
 
-			float getValue_(const QLineEdit* edit) const
-				throw(Exception::InvalidFormat);
+			/// @throws BALL::Exception::InvalidFormat
+			float getValue_(const QLineEdit* edit) const;
 
 			CharmmFF* charmm_;
 		};

--- a/include/BALL/VIEW/DIALOGS/coloringSettingsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/coloringSettingsDialog.h
@@ -56,9 +56,8 @@ namespace BALL
 			///
 			virtual void applySettingsTo(ColorProcessor& cp) const;
 
-			///
-			virtual ColorProcessor* createColorProcessor(ColoringMethod method) const
-				throw(Exception::InvalidOption);
+			/// @throws BALL::Exception::InvalidOption
+			virtual ColorProcessor* createColorProcessor(ColoringMethod method) const;
 
 			///
 			virtual void getSettings(const ColorProcessor& cp);

--- a/include/BALL/VIEW/DIALOGS/generateCrystalDialog.h
+++ b/include/BALL/VIEW/DIALOGS/generateCrystalDialog.h
@@ -64,8 +64,8 @@ namespace BALL
 				///
 				//void checkMenu(MainControl& mc);
 				
-				///
-				bool initSpaceGroupList() throw(Exception::FileNotFound);
+				/// @throws BALL::Exception::FileNotFound
+				bool initSpaceGroupList();
 				
 				///
 				bool generate();

--- a/include/BALL/VIEW/DIALOGS/lightSettings.h
+++ b/include/BALL/VIEW/DIALOGS/lightSettings.h
@@ -106,9 +106,16 @@ namespace BALL
 			void setPosition_(const Vector3& v);
 			void setDirection_(const Vector3& v);
 			void setAttenuation_(const Vector3& a);
-			Vector3 getDirection_() throw(Exception::InvalidFormat);
-			Vector3 getPosition_() throw(Exception::InvalidFormat);
-			Vector3 getAttenuation_() throw(Exception::InvalidFormat);
+
+			/// @throws BALL::Exception::InvalidFormat
+			Vector3 getDirection_();
+
+			/// @throws BALL::Exception::InvalidFormat
+			Vector3 getPosition_();
+
+			/// @throws BALL::Exception::InvalidFormat
+			Vector3 getAttenuation_();
+
 			void setControlsEnabled_(bool state);
 			Index getCurrentLightNumber_() const;
 

--- a/include/BALL/VIEW/DIALOGS/modelSettingsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/modelSettingsDialog.h
@@ -58,9 +58,8 @@ namespace BALL
 			///
 			virtual void applySettingsTo(ModelProcessor& cp) const;
 				
-			///
-			virtual ModelProcessor* createModelProcessor(ModelType type) const
-				throw(Exception::InvalidOption);
+			/// @throws BALL::Exception::InvalidOption
+			virtual ModelProcessor* createModelProcessor(ModelType type) const;
 
 			///
 			virtual void getSettings(const ModelProcessor& mp);

--- a/include/BALL/VIEW/DIALOGS/raytraceableContourSurfaceDialog.h
+++ b/include/BALL/VIEW/DIALOGS/raytraceableContourSurfaceDialog.h
@@ -94,8 +94,9 @@ class BALL_VIEW_EXPORT RaytraceableContourSurfaceDialog
 	private:
 	
 	float getValue_(const QAbstractSlider* slider) const;
-	float getValue_(const QLineEdit* edit) const
-		throw(Exception::InvalidFormat);
+
+	///  @throws BALL::Exception::InvalidFormat
+	float getValue_(const QLineEdit* edit) const;
 	
 
 	// the sliders min and max

--- a/include/BALL/VIEW/DIALOGS/stageSettings.h
+++ b/include/BALL/VIEW/DIALOGS/stageSettings.h
@@ -150,30 +150,26 @@ namespace BALL
 
 			private:
 			
-			///
-			Vector3 getTextureUpDirection_()
-				throw(Exception::InvalidFormat);
+			/// @throws BALL::Exception::InvalidFormat
+			Vector3 getTextureUpDirection_();
 			
 			///
 			void setTextureUpDirection_(const Vector3& tud);
 
-			///
-			float getUser2ScreenDistance_()
-				throw(Exception::InvalidFormat);
+			/// @throws BALL::Exception::InvalidFormat
+			float getUser2ScreenDistance_();
 			
 			///
 			void setUser2ScreenDistance_(const float& s2u);
 
-			///
-			float getUserEyeLevel_()
-				throw(Exception::InvalidFormat);
+			/// @throws BALL::Exception::InvalidFormat
+			float getUserEyeLevel_();
 			
 			///
 			void setUserEyeLevel_(const float& s2u);
 			
-			///
-			float getUserEyeDistance_()
-				throw(Exception::InvalidFormat);
+			/// @throws BALL::Exception::InvalidFormat
+			float getUserEyeDistance_();
 			
 			///
 			void setUserEyeDistance_(const float& s2u);

--- a/include/BALL/VIEW/KERNEL/modularWidget.h
+++ b/include/BALL/VIEW/KERNEL/modularWidget.h
@@ -109,10 +109,10 @@ namespace BALL
 					this method in their constructors. This method connects them to the
 					MainControl object.
 					\param  mwidget the ModularWidget to be registered to the MainControl
+					@throws BALL::Exception::NullPointer
 			*/
-			static void registerWidget(ModularWidget* mwidget)
-				throw(Exception::NullPointer);
-				
+			static void registerWidget(ModularWidget* mwidget);
+
 			/**	Initialize the widget.
 					This method is called automatically	immediately before the main application 
 					is started. It should add the widget's menu entries and connections (if required).

--- a/include/BALL/VIEW/KERNEL/serverWidget.h
+++ b/include/BALL/VIEW/KERNEL/serverWidget.h
@@ -95,9 +95,9 @@ namespace BALL
 					BALLViewServer(ServerWidget* parent, Size port, bool restart = true);
 
 					/** private methodes used for reacting to client requests.
+					 * @throws BALL::VIEW::ServerWidget::NotCompositeObject
 					*/
-					void sendObject()
-						throw(NotCompositeObject);
+					void sendObject();
 
 					virtual void run();
 

--- a/include/BALL/VIEW/KERNEL/stage.h
+++ b/include/BALL/VIEW/KERNEL/stage.h
@@ -256,15 +256,15 @@ namespace BALL
 
 					/** Write a raytracing material to a persistent stream.
 					 		@param pm the persistence manager
+					 		@throws BALL::Exception::GeneralException
 					 */
-					virtual void persistentWrite(PersistenceManager& pm, const char* name = 0) const
-						throw(Exception::GeneralException);
+					virtual void persistentWrite(PersistenceManager& pm, const char* name = 0) const;
 
 					/** Read a raytracing material from a persistent stream.
 					 		@param pm the persistence manager
+					 		@throws BALL::Exception::GeneralException
 					*/
-					virtual void persistentRead(PersistenceManager& pm)
-						throw(Exception::GeneralException);
+					virtual void persistentRead(PersistenceManager& pm);
 
 					//@}
 

--- a/include/BALL/VIEW/KERNEL/threads.h
+++ b/include/BALL/VIEW/KERNEL/threads.h
@@ -252,9 +252,8 @@ namespace VIEW
 				///
 				virtual ~MDSimulationThread();
 				
-				///
-				virtual void run()
-					throw(Exception::NullPointer);
+				/// @throws BALL::Exception::NullPointer
+				virtual void run();
 
 				///
 				void setMolecularDynamics(MolecularDynamics* md);
@@ -290,9 +289,8 @@ namespace VIEW
 				///
 				void setDockingAlgorithm(DockingAlgorithm* dock_alg);
 					
-				///
-				virtual void run()
-					throw(Exception::NullPointer);
+				/// @throws BALL::Exception::NullPointer
+				virtual void run();
 					
 			protected:
 				DockingAlgorithm* dock_alg_;

--- a/include/BALL/VIEW/MODELS/ballAndStickModel.h
+++ b/include/BALL/VIEW/MODELS/ballAndStickModel.h
@@ -94,10 +94,9 @@ namespace BALL
 
 			/** Change the radius of the ball-component.
 					\param       radius the new radius of the ball-component: (<b>radius > 0</b>)
-					\exception  OutOfRange thrown if <b>radius <= 0</b>
+					\exception  BALL::Exception::OutOfRange thrown if <b>radius <= 0</b>
 			*/
-			void setBallRadius(const float radius)
-				throw(Exception::OutOfRange);
+			void setBallRadius(const float radius);
 
 			/** Inspection of the radius of the ball-component.
 			*/
@@ -105,10 +104,9 @@ namespace BALL
 
 			/** Change the radius of the stick-component.
 					\param       radius the new radius of the stick-component: (radius > 0)
-					\exception  OutOfRange thrown if radius <= 0
+					\exception  BALL::Exception::OutOfRange thrown if radius <= 0
 			*/
-			void setStickRadius(const float radius)
-				throw(Exception::OutOfRange);
+			void setStickRadius(const float radius);
 
 			/** Inspection of the radius of the stick-component.
 			*/
@@ -196,8 +194,8 @@ namespace BALL
 
 			inline void renderMultipleBond_(const Bond& bond, Vector3 normal, Vector3 dir);
 
-			inline void renderDashedBond_(const Bond& bond, Vector3 n)
-				throw(Exception::DivisionByZero);
+			/// @throws BALL::Exception::DivisionByZero
+			inline void renderDashedBond_(const Bond& bond, Vector3 n);
 
 			void collectRingBonds_();
 

--- a/include/BALL/VIEW/RENDERING/RENDERERS/POVRenderer.h
+++ b/include/BALL/VIEW/RENDERING/RENDERERS/POVRenderer.h
@@ -59,9 +59,9 @@ namespace BALL
 
 			/** Detailed constructor.
 			 		\param name The name of the file we will create
+			 		\exception BALL::Exception::FileNotFound
 			 */
-			POVRenderer(const String& name)
-				throw(Exception::FileNotFound);
+			POVRenderer(const String& name);
 			
 			// Only for Python
 			POVRenderer(const POVRenderer& renderer);
@@ -80,9 +80,9 @@ namespace BALL
 
 			/** Sets the name of the file we will create.
 			 		\param name The file name
+			 		\exception BALL::Exception::FileNotFound
 			 */
-			void setFileName(const String& name)
-				throw(Exception::FileNotFound);
+			void setFileName(const String& name);
 
 			/// Set a stream as output device
 			void setOstream(std::ostream& out_stream);

--- a/include/BALL/VIEW/RENDERING/RENDERERS/STLRenderer.h
+++ b/include/BALL/VIEW/RENDERING/RENDERERS/STLRenderer.h
@@ -46,9 +46,9 @@ class BALL_VIEW_EXPORT STLRenderer
 
 	/** Detailed constructor.
 			\param name The name of the file we will create
+			\exception BALL::Exception::FileNotFound
 	 */
-	STLRenderer(const String& name)
-		throw(Exception::FileNotFound);
+	STLRenderer(const String& name);
 	
 	/// Destructor.
 	virtual ~STLRenderer();
@@ -63,9 +63,9 @@ class BALL_VIEW_EXPORT STLRenderer
 
 	/** Sets the name of the file we will create.
 			\param name The file name
+			\exception BALL::Exception::FileNotFound
 	 */
-	void setFileName(const String& name)
-		throw(Exception::FileNotFound);
+	void setFileName(const String& name);
 
 
 	/** Converts a Vector3 into a String in VRML format as stl works in the same perspektive.

--- a/include/BALL/VIEW/RENDERING/RENDERERS/VRMLRenderer.h
+++ b/include/BALL/VIEW/RENDERING/RENDERERS/VRMLRenderer.h
@@ -49,9 +49,9 @@ class BALL_VIEW_EXPORT VRMLRenderer : public Renderer
 
 	/** Detailed constructor.
 			\param name The name of the file we will create
+			\exception BALL::Exception::FileNotFound
 	 */
-	VRMLRenderer(const String& name)
-		throw(Exception::FileNotFound);
+	VRMLRenderer(const String& name);
 	
 	/// Destructor.
 	virtual ~VRMLRenderer();
@@ -66,9 +66,9 @@ class BALL_VIEW_EXPORT VRMLRenderer : public Renderer
 
 	/** Sets the name of the file we will create.
 			\param name The file name
+			\exception BALL::Exception::FileNotFound
 	 */
-	void setFileName(const String& name)
-		throw(Exception::FileNotFound);
+	void setFileName(const String& name);
 
 	/** Converts a ColorRGBA into a String in VRMLRay format.
 	 */

--- a/include/BALL/VIEW/RENDERING/RENDERERS/XML3DRenderer.h
+++ b/include/BALL/VIEW/RENDERING/RENDERERS/XML3DRenderer.h
@@ -63,9 +63,9 @@ namespace BALL
 
 			/** Detailed constructor.
 			 		\param name The name of the file we will create
+			 		\exception BALL::Exception::FileNotFound
 			 */
-			XML3DRenderer(const String& name)
-				throw(Exception::FileNotFound);
+			XML3DRenderer(const String& name);
 			
 			XML3DRenderer(std::ostream& name);
 			
@@ -88,9 +88,9 @@ namespace BALL
 
 			/** Sets the name of the file we will create.
 			 		\param name The file name
+			 		\exception BALL::Exception::FileNotFound
 			 */
-			void setFileName(const String& name)
-				throw(Exception::FileNotFound);
+			void setFileName(const String& name);
 
 			/// Set a stream as output device
 			void setOstream(std::ostream& out_stream);

--- a/include/BALL/VIEW/RENDERING/RENDERERS/cudaVolumeRenderer.h
+++ b/include/BALL/VIEW/RENDERING/RENDERERS/cudaVolumeRenderer.h
@@ -19,8 +19,8 @@ namespace BALL
 			public:			
 
             /* RT renderer methods */
-                virtual bool init(const Scene& scene) 
-                    throw(BALL::Exception::CUDAError)				
+                /// @throws BALL::Exception::CUDAError
+                virtual bool init(const Scene& scene)
             {
                 try
 	            {

--- a/include/BALL/VIEW/RENDERING/RENDERERS/raytracingRenderer.h
+++ b/include/BALL/VIEW/RENDERING/RENDERERS/raytracingRenderer.h
@@ -39,10 +39,10 @@ namespace BALL
 			 */
 			virtual bool supports(const PixelFormat &format) const;			
 
+			/// @throws BALL::Exception::FormatUnsupported
 			virtual Resolution getSupportedResolution(
 				const Resolution &min, const Resolution &max,
-				const PixelFormat &format) const
-                throw(BALL::Exception::FormatUnsupported);			
+				const PixelFormat &format) const;
 					
 			/*
 			 * Get description of the renderer int textual form

--- a/include/BALL/VIEW/RENDERING/glDisplayList.h
+++ b/include/BALL/VIEW/RENDERING/glDisplayList.h
@@ -135,14 +135,13 @@ class BALL_VIEW_EXPORT GLDisplayList
 			between a <b>startDefinition</b> and <b>endDefinition</b> command.
 			This method indicates the start of a display list. Every object drawn after
 			this method will be compiled into this glDisplayList.
-			\exception   NestedDisplayList thrown whenever a nested display list definition is tried.
-			\exception   NoDisplayListAvailable thrown whenever no memory for the display list is available.
-			\exception   DisplayListRedeclaration thrown whenever this glDisplayList is tried to redefine before 
+			\exception   BALL::VIEW::GLDisplayList::NestedDisplayList thrown whenever a nested display list definition is tried.
+			\exception   BALL::VIEW::GLDisplayList::NoDisplayListAvailable thrown whenever no memory for the display list is available.
+			\exception   BALL::VIEW::GLDisplayList::DisplayListRedeclaration thrown whenever this glDisplayList is tried to redefine before
 									 destroy is called.
 			\see         endDefinition
 	*/
-	void startDefinition()
-		throw(NestedDisplayList, NoDisplayListAvailable, DisplayListRedeclaration);
+	void startDefinition();
 
 	/** End the display list.
 			This method is the end command for a display list definition.

--- a/include/BALL/VIEW/RENDERING/renderTarget.h
+++ b/include/BALL/VIEW/RENDERING/renderTarget.h
@@ -233,10 +233,10 @@ namespace BALL
 			 *  specified in the constructor.
 			 *  The buffer will remain valid until update() is called with that buffer.
 			 *  Each call to getBuffer() creates a new FrameBuffer.
-			 *  @throw Exception::NoBufferAvailable if no new FrameBuffer can be created for this 
+			 *  @throw BALL::Exception::NoBufferAvailable if no new FrameBuffer can be created for this
 			 *         RenderTarget (e.g. if the RenderTarget supports only a single buffer at a time)
 			 */
-			virtual FrameBufferPtr getBuffer() throw(BALL::Exception::NoBufferAvailable) = 0;
+			virtual FrameBufferPtr getBuffer() = 0;
 
 			virtual FrameBufferFormat getFormat() const = 0;
 

--- a/include/BALL/VIEW/RENDERING/renderWindow.h
+++ b/include/BALL/VIEW/RENDERING/renderWindow.h
@@ -76,8 +76,9 @@ namespace BALL
 			 * See \link RenderTarget \endlink for general description.
 			 * In addition there is a precondition that \link init \endlink must be called before 
 			 * getBuffer. If not, \link NoBufferAvailable \endlink exception is thrown.
+			 * @throws BALL::Exception::NoBufferAvailable
 			 */
-			virtual FrameBufferPtr getBuffer() throw(BALL::Exception::NoBufferAvailable);            
+			virtual FrameBufferPtr getBuffer();
 
 			/*
 			 * See \link RenderTarget \endlink for description.

--- a/source/COMMON/exception.C
+++ b/source/COMMON/exception.C
@@ -335,7 +335,6 @@ namespace BALL
 			}
 
 			void GlobalExceptionHandler::newHandler()
-				throw(Exception::OutOfMemory)
 			{
 				throw Exception::OutOfMemory(__FILE__, __LINE__);
 			}

--- a/source/DOCKING/COMMON/dockResult.C
+++ b/source/DOCKING/COMMON/dockResult.C
@@ -98,7 +98,6 @@ namespace BALL
 		}
 
 		void DockResult::sortBy(Index scoring_index)
-			throw(Exception::IndexOverflow)
 		{
 			if (scoring_index >= (Index)scorings_.size())
 			{
@@ -116,7 +115,6 @@ namespace BALL
 
 		// i -> score row, j -> scoring column
 		float DockResult::operator()(Position i, Position j)
-			throw(Exception::IndexOverflow)
 		{
 			// check if i and j are valid
 			if (j >= scorings_.size())
@@ -143,7 +141,6 @@ namespace BALL
 
 		// returns sorted scores of scoring_ i
 		const vector < ConformationSet::Conformation > DockResult::getScores(Position i) const
-			throw(Exception::IndexOverflow)
 		{
 			if (i >= scorings_.size())
 			{
@@ -162,7 +159,6 @@ namespace BALL
 
 		//returns name of scoring function of scoring_ i
 		const String& DockResult::getScoringName(Position i) const
-			throw(Exception::IndexOverflow)
 		{
 			if (i >= scorings_.size())
 			{
@@ -174,7 +170,6 @@ namespace BALL
 
 		//returns options of scoring function of scoring_ i
 		const Options& DockResult::getScoringOptions(Position i) const
-			throw(Exception::IndexOverflow)
 		{
 			if (i >= scorings_.size())
 			{
@@ -211,7 +206,6 @@ namespace BALL
 
 		/// delete i-th Scoring_ of vector scorings_
 		void DockResult::deleteScoring(Position i)
-			throw(Exception::IndexOverflow)
 		{
 			if (i >= scorings_.size())
 			{

--- a/source/DOCKING/COMMON/result.C
+++ b/source/DOCKING/COMMON/result.C
@@ -219,7 +219,6 @@ namespace BALL
 	}
 
 	Conformation* Result::getInputConformer(Ligand* lig)
-			throw(Exception::GeneralException)
 	{
 		for (Position i = 0; i < lig->getNumberOfConformations(); i++)
 		{
@@ -234,7 +233,6 @@ namespace BALL
 	}
 
 	Conformation* Result::getFirstOutputConformation(Ligand* lig)
-			throw(Exception::GeneralException)
 	{
 		for (Position i = 0; i < lig->getNumberOfConformations(); i++)
 		{
@@ -403,7 +401,6 @@ namespace BALL
 		}
 		else
 		{
-			//throw(Exception::IndexOverflow(__FILE__, __LINE__, id, 1));
 			throw(Exception::InvalidArgument(__FILE__, __LINE__, "supplied id not found"));
 		}
 	}

--- a/source/FORMAT/dockResultFile.C
+++ b/source/FORMAT/dockResultFile.C
@@ -236,7 +236,6 @@ namespace BALL
 
 
 		Molecule* DockResultFile::read()
-			throw (Exception::ParseError)
 		{
 			if(!mode_read_)
 			{
@@ -309,7 +308,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::write(const Molecule& mol)
-			throw (BALL::File::CannotWrite)
 		{
 			if(mode_read_)
 			{
@@ -535,7 +533,6 @@ namespace BALL
 
 
 		Ligand* DockResultFile::readLigand()
-					throw(Exception::ParseError)
 		{
 			current_ligand_ = 0;
 			Ligand* ret = 0;
@@ -1055,7 +1052,6 @@ namespace BALL
 
 
 		bool DockResultFile::readResults_()
-					throw(Exception::ParseError)
 		{
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
 			{
@@ -1086,7 +1082,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readResult()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1149,7 +1144,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readSubResult()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1187,7 +1181,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readEntry()
-					throw(Exception::ParseError)
 		{
 			Result::ResultData rd;
 			HashMap<String,String> attrs;
@@ -1229,7 +1222,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readLigands()
-					throw(Exception::ParseError)
 		{
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
 			{
@@ -1260,7 +1252,6 @@ namespace BALL
 		}
 
 		void DockResultFile::buildLigand()
-				throw(Exception::ParseError)
 		{
 			current_ligand_ = new Ligand(current_molecule_);
 			current_ligand_->setId(current_ligand_id_);
@@ -1268,7 +1259,6 @@ namespace BALL
 		}
 
 		void DockResultFile::buildReceptor()
-				throw(Exception::ParseError)
 		{
 			current_receptor_ = new Receptor(current_protein_);
 			current_receptor_->setId(current_receptor_id_);
@@ -1276,7 +1266,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readLigand_()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1320,7 +1309,6 @@ namespace BALL
 
 
 		bool DockResultFile::readFlexibilities()
-					throw(Exception::ParseError)
 		{
 			flexdef_idx = 0;
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
@@ -1354,7 +1342,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readConformations(FlexibleMolecule* target)
-					throw(Exception::ParseError)
 		{
 			target->clearConformations();
 
@@ -1397,7 +1384,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readConformation(Conformation* conformation)
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1443,7 +1429,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readFlexibility()
-					throw(Exception::ParseError)
 		{
 			current_flexdef_ = FlexDefinition();
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
@@ -1478,7 +1463,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readFullFlexResidue()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1505,7 +1489,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readRotamericResidue()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1535,7 +1518,6 @@ namespace BALL
 
 
 		bool DockResultFile::readCoordinates()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1598,7 +1580,6 @@ namespace BALL
 
 
 		void DockResultFile::buildMolecule()
-			throw(Exception::ParseError)
 		{
 			current_molecule_ = new Molecule();
 			current_molecule_->setName(current_molecule_name_);
@@ -1636,7 +1617,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readMolecule()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1677,7 +1657,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readAtoms()
-					throw(Exception::ParseError)
 		{
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
 			{
@@ -1706,7 +1685,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readAtom()
-					throw(Exception::ParseError)
 		{
 			current_atom_ = new Atom();
 			HashMap<String,String> attrs;
@@ -1769,7 +1747,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readBonds()
-					throw(Exception::ParseError)
 		{
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
 			{
@@ -1798,7 +1775,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readBond()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1833,7 +1809,6 @@ namespace BALL
 
 
 		bool DockResultFile::readReceptors_()
-					throw(Exception::ParseError)
 		{
 			while(!xmlIn_->atEnd() && !xmlIn_->hasError())
 			{
@@ -1864,7 +1839,6 @@ namespace BALL
 		}
 
 		Receptor* DockResultFile::readReceptor()
-				throw(Exception::ParseError)
 		{
 			current_receptor_ = 0;
 			readReceptor_();
@@ -1872,7 +1846,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readReceptor_()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -1920,7 +1893,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readProtein()
-					throw(Exception::ParseError)
 		{
 			current_chain_ = new Chain;
 			HashMap<String,String> attrs;
@@ -1955,7 +1927,6 @@ namespace BALL
 		}
 
 		void DockResultFile::buildProtein()
-				throw(Exception::ParseError)
 		{
 			current_protein_ = new Protein();
 			current_protein_->insert(*current_chain_);
@@ -1963,7 +1934,6 @@ namespace BALL
 		}
 
 		void DockResultFile::buildResidue()
-				throw(Exception::ParseError)
 		{
 			for(unsigned int i=0;i<current_PDB_atoms_.size();i++)
 			{
@@ -1977,7 +1947,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readResidue()
-					throw(Exception::ParseError)
 		{
 			HashMap<String,String> attrs;
 			attributesToHashMap(xmlIn_->attributes(),attrs);
@@ -2017,7 +1986,6 @@ namespace BALL
 		}
 
 		bool DockResultFile::readPDBAtom()
-					throw(Exception::ParseError)
 		{
 			PDBAtom* atm = new PDBAtom();
 			HashMap<String,String> attrs;

--- a/source/MOLMEC/AMBER/GAFFTypeProcessor.C
+++ b/source/MOLMEC/AMBER/GAFFTypeProcessor.C
@@ -100,7 +100,6 @@ namespace BALL
 	//and their TypeDefinition in corresponding vector
 	//and store a GAFFCESParser for every CESstring
 	void GAFFTypeProcessor::parseAtomtypeTableFile_()
-		throw(Exception::FileNotFound)
 	{
 		StringHashMap<GAFFCESParser*>::Iterator parser_it = ces_parsers_.begin();
 		for (; parser_it != ces_parsers_.end(); ++parser_it)

--- a/source/MOLMEC/AMBER/amber.C
+++ b/source/MOLMEC/AMBER/amber.C
@@ -148,7 +148,6 @@ namespace BALL
 	}
 
 	bool AmberFF::specificSetup()
-		throw(Exception::TooManyErrors)
 	{
 		// check whether the system is assigned
 		if (getSystem() == 0)

--- a/source/MOLMEC/AMBER/amberBend.C
+++ b/source/MOLMEC/AMBER/amberBend.C
@@ -35,7 +35,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool AmberBend::setup()
-		throw(Exception::TooManyErrors)
 	{
 		// clear old bends:
 		bend_.clear();

--- a/source/MOLMEC/AMBER/amberNonBonded.C
+++ b/source/MOLMEC/AMBER/amberNonBonded.C
@@ -207,7 +207,6 @@ namespace BALL
 	}
 
 	void AmberNonBonded::update()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{
@@ -364,7 +363,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool AmberNonBonded::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{
@@ -539,7 +537,6 @@ namespace BALL
 		(const vector<pair<Atom*, Atom*> >& atom_vector,
 		 const LennardJones& lennard_jones, 
 		 const Potential1210& hydrogen_bond)
-		throw(Exception::TooManyErrors)
 	{
 		// throw away the old rubbish
 		non_bonded_.clear();

--- a/source/MOLMEC/AMBER/amberStretch.C
+++ b/source/MOLMEC/AMBER/amberStretch.C
@@ -35,7 +35,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool AmberStretch::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{

--- a/source/MOLMEC/AMBER/amberTorsion.C
+++ b/source/MOLMEC/AMBER/amberTorsion.C
@@ -52,7 +52,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool AmberTorsion::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{

--- a/source/MOLMEC/CHARMM/charmm.C
+++ b/source/MOLMEC/CHARMM/charmm.C
@@ -155,7 +155,6 @@ namespace BALL
 
 	// force field specific setup method
 	bool CharmmFF::specificSetup()
-		throw(Exception::TooManyErrors)
 	{
 		// check whether the system is assigned
 		if (getSystem() == 0)

--- a/source/MOLMEC/CHARMM/charmmBend.C
+++ b/source/MOLMEC/CHARMM/charmmBend.C
@@ -35,7 +35,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool CharmmBend::setup()
-		throw(Exception::TooManyErrors)
 	{
 		// clear old bends:
 		bend_.clear();

--- a/source/MOLMEC/CHARMM/charmmImproperTorsion.C
+++ b/source/MOLMEC/CHARMM/charmmImproperTorsion.C
@@ -52,7 +52,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool CharmmImproperTorsion::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{

--- a/source/MOLMEC/CHARMM/charmmNonBonded.C
+++ b/source/MOLMEC/CHARMM/charmmNonBonded.C
@@ -211,7 +211,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool CharmmNonBonded::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{
@@ -490,7 +489,6 @@ namespace BALL
 	// Build a vector of non-bonded atom pairs with the vdw parameters 
 	// The vector starts with 1-4 interactions
 	void CharmmNonBonded::buildVectorOfNonBondedAtomPairs(const vector<pair<Atom*, Atom*> >& atom_vector)
-		throw(Exception::TooManyErrors)
 	{
 		// throw away the old rubbish
 		non_bonded_.clear();

--- a/source/MOLMEC/CHARMM/charmmStretch.C
+++ b/source/MOLMEC/CHARMM/charmmStretch.C
@@ -36,7 +36,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool CharmmStretch::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{

--- a/source/MOLMEC/CHARMM/charmmTorsion.C
+++ b/source/MOLMEC/CHARMM/charmmTorsion.C
@@ -53,7 +53,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool CharmmTorsion::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{

--- a/source/MOLMEC/COMMON/forceField.C
+++ b/source/MOLMEC/COMMON/forceField.C
@@ -524,7 +524,6 @@ namespace BALL
 	}
 
 	void ForceField::update()
-		throw(Exception::TooManyErrors)
 	{
 		// check for validity of the force field
 		if (!valid_)
@@ -548,8 +547,7 @@ namespace BALL
 	}
 	
 
-	bool ForceField::specificSetup() 
-		throw(Exception::TooManyErrors)
+	bool ForceField::specificSetup()
 	{
 		return true;
 	}
@@ -642,7 +640,7 @@ namespace BALL
 		return unassigned_atoms_;
 	}
 
-	std::ostream& ForceField::error() throw(Exception::TooManyErrors)
+	std::ostream& ForceField::error()
 	{
 		number_of_errors_++;
 		if (number_of_errors_ > max_number_of_errors_)

--- a/source/MOLMEC/COMMON/forceFieldComponent.C
+++ b/source/MOLMEC/COMMON/forceFieldComponent.C
@@ -47,14 +47,12 @@ namespace BALL
 
 	// setup
 	bool ForceFieldComponent::setup()
-		throw(Exception::TooManyErrors)
 	{
 		return true;
 	}
 
 	// update pair lists - empty!
 	void update()
-		throw(Exception::TooManyErrors)
 	{
 	}
 
@@ -98,7 +96,6 @@ namespace BALL
 	}
 
 	void ForceFieldComponent::update()
-		throw(Exception::TooManyErrors)
 	{
 	}
 

--- a/source/MOLMEC/COMMON/snapShot.C
+++ b/source/MOLMEC/COMMON/snapShot.C
@@ -180,7 +180,6 @@ namespace BALL
 
 
 	void SnapShot::takeSnapShot(const System& system)
-		throw(Exception::OutOfMemory)
 	{
 		number_of_atoms_ = system.countAtoms();
 
@@ -232,7 +231,6 @@ namespace BALL
 
 
 	void SnapShot::getAtomPositions(const System& system)
-		throw(Exception::OutOfMemory)
 	{
 		// obtain the number of atoms
 		number_of_atoms_ = system.countAtoms();
@@ -269,7 +267,6 @@ namespace BALL
 
 
 	void SnapShot::getAtomVelocities(const System& system)
-		throw(Exception::OutOfMemory)
 	{
 		number_of_atoms_ = system.countAtoms();
 		atom_velocities_.resize(number_of_atoms_);
@@ -302,7 +299,6 @@ namespace BALL
 
 
 	void SnapShot::getAtomForces(const System& system)
-		throw(Exception::OutOfMemory)
 	{
 		number_of_atoms_ = system.countAtoms();
 		atom_forces_.resize(number_of_atoms_);

--- a/source/MOLMEC/COMMON/snapShotManager.C
+++ b/source/MOLMEC/COMMON/snapShotManager.C
@@ -386,7 +386,7 @@ namespace BALL
 	// snapshots has been taken, all snapshots so far are saved to disk The
 	// first snapshot taken (and with no other previous snapshots in a file)
 	// has index 1. 
-	void SnapShotManager::takeSnapShot() throw(File::CannotWrite)
+	void SnapShotManager::takeSnapShot()
 	{
 		if (system_ptr_ == 0) return;
 
@@ -580,7 +580,6 @@ namespace BALL
 
 	// This method writes all snapshots in memory to the snapshot file on disk
 	void SnapShotManager::flushToDisk()
-		throw(File::CannotWrite)
 	{
 		// if no snapshots are in main memory, then there is nothing to do
 		// also abort, if no trajectory file was set

--- a/source/MOLMEC/COMMON/support.C
+++ b/source/MOLMEC/COMMON/support.C
@@ -36,7 +36,6 @@ namespace BALL
 			 double distance,
 			 bool periodic_boundary_enabled, 
 			 PairListAlgorithmType type)
-			throw(Exception::OutOfMemory)
 		{
 #ifdef BALL_BENCHMARK
 	Timer t;

--- a/source/MOLMEC/MMFF94/MMFF94.C
+++ b/source/MOLMEC/MMFF94/MMFF94.C
@@ -144,7 +144,6 @@ namespace BALL
 	}
 
 	bool MMFF94::specificSetup()
-		throw(Exception::TooManyErrors)
 	{
 		// check whether the system is assigned
 		if (getSystem() == 0) return false;

--- a/source/MOLMEC/MMFF94/MMFF94NonBonded.C
+++ b/source/MOLMEC/MMFF94/MMFF94NonBonded.C
@@ -138,7 +138,6 @@ namespace BALL
 	}
 
 	void MMFF94NonBonded::update()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0) 
 		{
@@ -186,7 +185,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool MMFF94NonBonded::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0 ||
 				!dynamic_cast<MMFF94*>(getForceField()))

--- a/source/MOLMEC/MMFF94/MMFF94OutOfPlaneBend.C
+++ b/source/MOLMEC/MMFF94/MMFF94OutOfPlaneBend.C
@@ -65,9 +65,10 @@ namespace BALL
 	}
 
 
-	// setup the internal datastructures for the component
+	/** setup the internal datastructures for the component
+	 *  @throws BALL::Exception::TooManyErrors
+	 */
 	bool MMFF94OutOfPlaneBend::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0 ||
 				dynamic_cast<MMFF94*>(getForceField()) == 0) 

--- a/source/MOLMEC/MMFF94/MMFF94Parameters.C
+++ b/source/MOLMEC/MMFF94/MMFF94Parameters.C
@@ -36,7 +36,6 @@ namespace BALL
 	}
 
 	bool MMFF94ParametersBase::readParameters(Parameters& p, const String& section)
-		throw(Exception::FileNotFound)
 	{
 		ParameterSection p_sec;
 		p_sec.extractSection(p, section);
@@ -638,7 +637,6 @@ bool MMFF94StretchBendParameters::setup_(const vector<vector<String> >& lines)
 
 
 bool MMFF94StretchBendParameters::readEmpiricalParameters(Parameters& p, const String& section)
-	throw(Exception::FileNotFound)
 {
 	ParameterSection p_sec;
 	p_sec.extractSection(p, section);
@@ -1217,7 +1215,6 @@ double MMFF94ESParameters::getPartialCharge(Position at1, Position at2, Position
 }
 
 bool MMFF94ESParameters::readEmpiricalParameters(Parameters& p, const String& section)
-	throw(Exception::FileNotFound)
 {
 	phis_.resize(MMFF94_number_atom_types);
 	pbcis_.resize(MMFF94_number_atom_types);

--- a/source/MOLMEC/MMFF94/MMFF94StretchBend.C
+++ b/source/MOLMEC/MMFF94/MMFF94StretchBend.C
@@ -121,7 +121,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool MMFF94StretchBend::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0 || getForceField()->getSystem() == 0) 
 		{

--- a/source/MOLMEC/MMFF94/MMFF94Torsion.C
+++ b/source/MOLMEC/MMFF94/MMFF94Torsion.C
@@ -84,7 +84,6 @@ namespace BALL
 
 	// setup the internal datastructures for the component
 	bool MMFF94Torsion::setup()
-		throw(Exception::TooManyErrors)
 	{
 		if (getForceField() == 0 ||
 				dynamic_cast<MMFF94*>(getForceField()) == 0) 

--- a/source/NMR/createSpectrumProcessor.C
+++ b/source/NMR/createSpectrumProcessor.C
@@ -18,7 +18,6 @@ namespace BALL
 	const String CreateSpectrumProcessor::AVERAGE_SECTION_NAME =  "AverageAtoms";
 
 	CreateSpectrumProcessor::CreateSpectrumProcessor()
-		throw(Exception::FileNotFound, Exception::ParseError)
 		:	width_(1.0),
 			use_averaging_(true),
 			use_ignore_table_(true),
@@ -49,7 +48,6 @@ namespace BALL
 	}
 
 	void CreateSpectrumProcessor::init(const String& filename)
-		throw(Exception::ParseError, Exception::FileNotFound)
 	{
 		valid_ = false;
 

--- a/source/NMR/empiricalHSShiftProcessor.C
+++ b/source/NMR/empiricalHSShiftProcessor.C
@@ -1571,7 +1571,6 @@ namespace BALL
 	
 	EmpiricalHSShiftProcessor::ShiftHyperSurface_::ShiftHyperSurface_(String filename, String /* atomtype */,
 		String firstproperty, String secondproperty, int verbosity)
-		throw(Exception::FileNotFound)
 		:	type_(),
 			first_property_(),
 			second_property_(),

--- a/source/NMR/shiftModel.C
+++ b/source/NMR/shiftModel.C
@@ -89,7 +89,6 @@ namespace BALL
 	}
 
 	void ShiftModel::setFilename(const String& filename)
-		throw(Exception::FileNotFound)
 	{
 		// set the parameter filename 
 		parameters_.setFilename(filename);
@@ -139,7 +138,6 @@ namespace BALL
 	}
 
 	bool ShiftModel::init_()
-		throw(Exception::FileNotFound)
 	{
 		// inivalidate object
 		valid_ = false;
@@ -194,8 +192,7 @@ namespace BALL
 	}
 
 	void ShiftModel::registerModule(const String& name, CreateMethod create_method)
-		throw(Exception::NullPointer)
-	{	
+	{
 		// check that we did not get something strange
 		if (create_method == 0)
 		{

--- a/source/NMR/shiftModel1D.C
+++ b/source/NMR/shiftModel1D.C
@@ -97,7 +97,6 @@ namespace BALL
 	}
 
 	bool  ShiftModel1D::init_()
-			throw(Exception::FileNotFound)
 	{
 		valid_ = true;
 
@@ -107,7 +106,6 @@ namespace BALL
 	}
 
 	void ShiftModel1D::setFilename(const String& filename)
-			throw(Exception::FileNotFound)
 	{
 		// set the parameter filename 
 		parameters_.setFilename(filename);

--- a/source/NMR/shiftModel2D.C
+++ b/source/NMR/shiftModel2D.C
@@ -95,7 +95,6 @@ namespace BALL
 	}
 	
 	bool  ShiftModel2D::init_()
-			throw(Exception::FileNotFound)
 	{
 		valid_ = true;
 
@@ -105,7 +104,6 @@ namespace BALL
 	}
 
 	void ShiftModel2D::setFilename(const String& filename)
-			throw(Exception::FileNotFound)
 	{
 		// set the parameter filename 
 		parameters_.setFilename(filename);

--- a/source/SCORING/COMPONENTS/PLP.C
+++ b/source/SCORING/COMPONENTS/PLP.C
@@ -328,7 +328,6 @@ void PLP::update(const vector<pair<Atom*, Atom*> >& atom_vector)
 
 
 void PLP::update()
-	throw(Exception::TooManyErrors)
 {
 	cout<<"PLP::update() !!"<<endl;
 	cout<<"Use only PLP::update(const AtomPairVector&)"<<endl;

--- a/source/SCORING/FUNCTIONS/forceFieldEvaluation.C
+++ b/source/SCORING/FUNCTIONS/forceFieldEvaluation.C
@@ -64,7 +64,6 @@ using namespace BALL;
 	}
 
 	std::vector < ConformationSet::Conformation > ForceFieldEvaluation::operator () (ConformationSet& conformations)
-		throw(Exception::TooManyErrors)
 	{
 		std::vector < ConformationSet::Conformation > result;
 		if (!ff_) return result;

--- a/source/SOLVATION/electrostaticPotentialCalculator.C
+++ b/source/SOLVATION/electrostaticPotentialCalculator.C
@@ -36,7 +36,6 @@ namespace BALL
 	}
 
 	void ElectrostaticPotentialCalculator::apply(System &S)
-		throw(Exception::NullPointer)
 	{
 		if (frag_db_ == 0)
 		{

--- a/source/SOLVATION/generalizedBornCase.C
+++ b/source/SOLVATION/generalizedBornCase.C
@@ -53,7 +53,6 @@ namespace BALL
 	*/
 
 	GeneralizedBornModel::GeneralizedBornModel()
-		throw(Exception::FileNotFound)
 		: ac_(0),
 			born_radii_(),
 			pair_list_(),
@@ -125,7 +124,6 @@ namespace BALL
 
 
 	bool GeneralizedBornModel::setup(const AtomContainer& ac)
-		throw(Exception::FileNotFound)
 	{
 		
 		Timer timer;
@@ -448,7 +446,6 @@ namespace BALL
 
 
 	bool GeneralizedBornModel::readScalingFactors(const String& filename)
-		throw(Exception::FileNotFound)
 	{
 
 		Path path;

--- a/source/SOLVATION/pair6_12InteractionEnergyProcessor.C
+++ b/source/SOLVATION/pair6_12InteractionEnergyProcessor.C
@@ -174,7 +174,6 @@ namespace BALL
 
 
 	bool Pair6_12InteractionEnergyProcessor::finish() 
-		throw(Exception::DivisionByZero)
 	{
 
 		// how loud will we cry?

--- a/source/SOLVATION/solventDescriptor.C
+++ b/source/SOLVATION/solventDescriptor.C
@@ -113,7 +113,6 @@ namespace BALL
 	}
 
 	const SolventAtomDescriptor& SolventDescriptor::getAtomDescriptor(Position index) const 
-		throw(Exception::IndexOverflow)
 	{
 		if (index >= solvent_atoms_.size())
 		{
@@ -124,7 +123,6 @@ namespace BALL
 	}
 
 	SolventAtomDescriptor& SolventDescriptor::getAtomDescriptor(Position index)  
-		throw(Exception::IndexOverflow)
 	{
 		if (index >= solvent_atoms_.size())
 		{

--- a/source/STRUCTURE/RMSDMinimizer.C
+++ b/source/STRUCTURE/RMSDMinimizer.C
@@ -39,7 +39,6 @@ namespace BALL
 
 	RMSDMinimizer::Result RMSDMinimizer::computeTransformation
 		(const AtomBijection& ab)
-		throw(RMSDMinimizer::IncompatibleCoordinateSets, RMSDMinimizer::TooFewCoordinates)
 	{
 		RMSDMinimizer::PointVector X(ab.size());
 		RMSDMinimizer::PointVector Y(ab.size());
@@ -53,7 +52,6 @@ namespace BALL
 
 	std::pair<Matrix4x4, double> RMSDMinimizer::computeTransformation
 		(const RMSDMinimizer::PointVector& A, const RMSDMinimizer::PointVector& B)
-		throw(RMSDMinimizer::IncompatibleCoordinateSets, RMSDMinimizer::TooFewCoordinates)
 	{
 		// Copy the point sets so we can remove the barycenters easily
 		PointVector X(A);
@@ -148,7 +146,6 @@ namespace BALL
 	}
 
 	double RMSDMinimizer::minimizeRMSD(AtomContainer& a, AtomContainer& b)
-		throw(RMSDMinimizer::IncompatibleCoordinateSets, RMSDMinimizer::TooFewCoordinates)
 	{
 		StructureMapper sm(a, b);
 		sm.calculateDefaultBijection();

--- a/source/STRUCTURE/RSEdge.C
+++ b/source/STRUCTURE/RSEdge.C
@@ -226,7 +226,6 @@ namespace BALL
 
 
 	TVector3<double> RSEdge::getIntersectionPoint(Position i) const
-		throw(Exception::GeneralException)
 	{
 		if (!singular_)
 		{

--- a/source/STRUCTURE/RSFace.C
+++ b/source/STRUCTURE/RSFace.C
@@ -40,7 +40,6 @@ namespace BALL
 			const TVector3<double>& normal,
 			bool singular,
 			Index index)
-		throw(Exception::DivisionByZero)
 		:	GraphTriangle< RSVertex,RSEdge,RSFace >
 					(vertex1,vertex2,vertex3,edge1,edge2,edge3,index),
 			center_(center),
@@ -94,7 +93,6 @@ namespace BALL
 			const TVector3<double>& normal,
 			bool singular,
 			Index index)
-		throw(Exception::DivisionByZero)
 	{
 		GraphTriangle< RSVertex,RSEdge,RSFace >::set
 				(vertex1,vertex2,vertex3,edge1,edge2,edge3,index);
@@ -187,7 +185,6 @@ namespace BALL
 
 
 	void RSFace::setNormal(const TVector3<double>& normal)
-		throw(Exception::DivisionByZero)
 	{
 		normal_ = normal;
 		normal_.normalize();

--- a/source/STRUCTURE/SESVertex.C
+++ b/source/STRUCTURE/SESVertex.C
@@ -109,7 +109,6 @@ namespace BALL
 
 
 	void SESVertex::setNormal(const TVector3<double>& normal)
-		throw(Exception::DivisionByZero)
 	{
 		normal_ = normal;
 		normal_.normalize();

--- a/source/STRUCTURE/assignBondOrderProcessor.C
+++ b/source/STRUCTURE/assignBondOrderProcessor.C
@@ -627,7 +627,6 @@ cout << "preassignPenaltyClasses_:" << preassignPenaltyClasses_() << " precomput
 
 
 	bool AssignBondOrderProcessor::readAtomPenalties_()
-		throw(Exception::FileNotFound())
 	{
 		// Open parameter file
 		Path    path;
@@ -1297,7 +1296,6 @@ cout << " ~~~~~~~~ added hydrogen dump ~~~~~~~~~~~~~~~~" << endl;
 
 
 	const System& AssignBondOrderProcessor::getSolution(Position i)
-		throw(Exception::IndexOverflow)
 	{
 		if (i >= solutions_.size())
 		{

--- a/source/STRUCTURE/buildBondsProcessor.C
+++ b/source/STRUCTURE/buildBondsProcessor.C
@@ -47,7 +47,7 @@ namespace BALL
 		min_bond_lengths_ = bbp.min_bond_lengths_;
 	}
 
-	BuildBondsProcessor::BuildBondsProcessor(const String& file_name)	throw(Exception::FileNotFound)
+	BuildBondsProcessor::BuildBondsProcessor(const String& file_name)
 		:	UnaryProcessor<AtomContainer>(),
 			options(),
 			num_bonds_(0),
@@ -431,7 +431,7 @@ namespace BALL
 		return order;
 	}
 
-	void BuildBondsProcessor::setBondLengths(const String& file_name) throw(Exception::FileNotFound)
+	void BuildBondsProcessor::setBondLengths(const String& file_name)
 	{
 		bond_lengths_.clear();
 		min_bond_lengths_.clear();
@@ -440,7 +440,7 @@ namespace BALL
 		readBondLengthsFromFile_(file_name);
 	}
 
-	void BuildBondsProcessor::readBondLengthsFromFile_(const String& file_name) throw(Exception::FileNotFound)
+	void BuildBondsProcessor::readBondLengthsFromFile_(const String& file_name)
 	{
 		// test file or set default file
 		String filename(file_name);

--- a/source/STRUCTURE/defaultProcessors.C
+++ b/source/STRUCTURE/defaultProcessors.C
@@ -36,7 +36,6 @@ namespace BALL
 	}
 
 	AssignRadiusProcessor::AssignRadiusProcessor(const String& filename)
-		throw(Exception::FileNotFound)
 		:	number_of_errors_(0),
 			number_of_assignments_(0)
 	{
@@ -145,7 +144,6 @@ namespace BALL
 	}
 
 	bool AssignRadiusProcessor::buildTable_()
-		throw(Exception::FileNotFound)
 	{
 		ifstream infile(filename_.c_str());
 
@@ -195,7 +193,6 @@ namespace BALL
 	}
 
 	void AssignRadiusProcessor::setFilename(const String& filename)
-		throw(Exception::FileNotFound)
 	{
 		Path path;
 		filename_ = path.find(filename);
@@ -220,7 +217,6 @@ namespace BALL
 	}
 
 	AssignChargeProcessor::AssignChargeProcessor(const String& filename)
-		throw(Exception::FileNotFound)
 		: AssignRadiusProcessor(filename),
 			total_charge_(0.0)
 	{

--- a/source/STRUCTURE/geometricProperties.C
+++ b/source/STRUCTURE/geometricProperties.C
@@ -284,7 +284,6 @@ namespace BALL
 
   // Calculate the torsion angle between four atoms
   Angle calculateTorsionAngle(const Atom& a1, const Atom& a2, const Atom& a3, const Atom& a4)
-		throw(Exception::IllegalPosition)
 	{
 		Vector3 a12(a2.getPosition() - a1.getPosition());
 Vector3 a23(a3.getPosition() - a2.getPosition());
@@ -394,7 +393,6 @@ Vector3 a23(a3.getPosition() - a2.getPosition());
 
   // Calculate the bond angle between three atoms
   Angle calculateBondAngle(const Atom& a1, const Atom& a2, const Atom& a3)
-		throw(Exception::IllegalPosition)
 	{
 		// two atoms can't have the same position
 		if (a1.getPosition() == a2.getPosition() ||

--- a/source/STRUCTURE/hybridisationProcessor.C
+++ b/source/STRUCTURE/hybridisationProcessor.C
@@ -63,7 +63,7 @@ namespace BALL
 	{
 	}
 
-	HybridisationProcessor::HybridisationProcessor(const String& smarts_file_name, const String& gaff_angle_file_name)	throw(Exception::FileNotFound)
+	HybridisationProcessor::HybridisationProcessor(const String& smarts_file_name, const String& gaff_angle_file_name)
 		:	UnaryProcessor<AtomContainer>(),
 			options(),
 			num_hybridisation_states_(0)
@@ -523,15 +523,13 @@ if (!openNbr)
 		return Processor::BREAK;
 	}
 
-	void HybridisationProcessor::setAtomTypeSmarts(const String& file_name) 
-		throw(Exception::FileNotFound)
+	void HybridisationProcessor::setAtomTypeSmarts(const String& file_name)
 	{
 		atom_type_smarts_.clear();
 		valid_ = readAtomTypeSmartsFromFile_(file_name);
 	}
 	
 	bool HybridisationProcessor::readAndInitBondAnglesFromFile_(const String& file_name) 
-		throw (Exception::FileNotFound)
 	{
 		// test file or set default file
 		String filename(file_name);
@@ -623,7 +621,6 @@ if (!openNbr)
 	
 
 	bool HybridisationProcessor::readAtomTypeSmartsFromFile_(const String& file_name) 
-		throw(Exception::FileNotFound)
 	{
 		// test file or set default file
 		String filename(file_name);

--- a/source/STRUCTURE/peptides.C
+++ b/source/STRUCTURE/peptides.C
@@ -140,7 +140,6 @@ namespace BALL
 		}
 		
 		void NameConverter::readConversionTable_()
-			throw (Exception::FileNotFound())
 		{
 			// Open parameter file
 			Path path;
@@ -207,7 +206,6 @@ namespace BALL
 		}
 		
 		void NameConverter::readPseudoAtomsConversionTable_()
-			throw (Exception::FileNotFound())
 		{
 			// Open parameter file
 			Path path;

--- a/source/STRUCTURE/reducedSurface.C
+++ b/source/STRUCTURE/reducedSurface.C
@@ -191,7 +191,6 @@ namespace BALL
 	}
 
 	TSphere3<double> ReducedSurface::getSphere(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_atoms_)
 		{
@@ -204,7 +203,6 @@ namespace BALL
 	}
 
 	RSVertex* ReducedSurface::getVertex(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_vertices_)
 		{
@@ -217,7 +215,6 @@ namespace BALL
 	}
 
 	RSEdge* ReducedSurface::getEdge(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_edges_)
 		{
@@ -230,7 +227,6 @@ namespace BALL
 	}
 
 	RSFace* ReducedSurface::getFace(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_faces_)
 		{
@@ -1191,7 +1187,6 @@ namespace BALL
 	}
 
 	Position RSComputer::getStartPosition()
-		throw(Exception::DivisionByZero)
 	{
 		if (findFirstFace() != NULL)
 		{
@@ -1209,7 +1204,6 @@ namespace BALL
 	}
 
 	RSFace* RSComputer::findFirstFace()
-		throw(Exception::DivisionByZero)
 	{
 		for (Position direction = 0; direction < 3; direction++)
 		{
@@ -1262,7 +1256,6 @@ namespace BALL
 	}
 
 	RSFace* RSComputer::findFace(Position direction, Position extrem)
-		throw(Exception::DivisionByZero)
 	{
 		Index a1 = findFirstAtom(direction, extrem);
 		if (a1 == -1)

--- a/source/STRUCTURE/residueRotamerSet.C
+++ b/source/STRUCTURE/residueRotamerSet.C
@@ -304,7 +304,7 @@ namespace BALL
 		return number_of_torsions_;
 	}
 
-	const Rotamer& ResidueRotamerSet::operator [] (Position index) const throw(Exception::IndexOverflow)
+	const Rotamer& ResidueRotamerSet::operator [] (Position index) const
 	{
   	if (index >= rotamers_.size())
     {
@@ -315,7 +315,6 @@ namespace BALL
 
 	// set the number of torsions
 	void ResidueRotamerSet::setNumberOfTorsions(Size number_of_torsions)
-		throw(Exception::IndexOverflow)
 	{
 		if (number_of_torsions > 4)
 		{

--- a/source/STRUCTURE/smartsParser.C
+++ b/source/STRUCTURE/smartsParser.C
@@ -730,7 +730,6 @@ namespace BALL
 	}
 
 	void SmartsParser::parse(const String& s)
-		throw(Exception::ParseError)
 	{
 		// clear out stuff from previous run
 		clear();

--- a/source/STRUCTURE/smilesParser.C
+++ b/source/STRUCTURE/smilesParser.C
@@ -109,7 +109,6 @@ namespace BALL
 	}
 
 	void SmilesParser::parse(const String& s)
-		throw(Exception::ParseError)
 	{
 		// clear out previous atoms
 		for (Position i = 0; i < all_atoms_.size(); i++)

--- a/source/STRUCTURE/solventAccessibleSurface.C
+++ b/source/STRUCTURE/solventAccessibleSurface.C
@@ -78,7 +78,6 @@ namespace BALL
 	}
 
 	void SolventAccessibleSurface::setVertex(SASVertex* vertex, Position i)
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_vertices_)
 		{
@@ -91,7 +90,6 @@ namespace BALL
 	}
 
 	SASVertex* SolventAccessibleSurface::getVertex(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_vertices_)
 		{
@@ -109,7 +107,6 @@ namespace BALL
 	}
 		
 	void SolventAccessibleSurface::setEdge(SASEdge* edge, Position i)
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_edges_)
 		{
@@ -122,7 +119,6 @@ namespace BALL
 	}
 
 	SASEdge* SolventAccessibleSurface::getEdge(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_edges_)
 		{
@@ -140,7 +136,6 @@ namespace BALL
 	}
 		
 	void SolventAccessibleSurface::setFace(SASFace* face, Position i)
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_faces_)
 		{
@@ -153,7 +148,6 @@ namespace BALL
 	}
 
 	SASFace* SolventAccessibleSurface::getFace(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i < number_of_faces_)
 		{

--- a/source/STRUCTURE/solventExcludedSurface.C
+++ b/source/STRUCTURE/solventExcludedSurface.C
@@ -627,7 +627,6 @@ namespace BALL
 
 
 	void SolventExcludedSurface::compute()
-		throw(Exception::GeneralException)
 	{
 		SESComputer sesc(this);
 		sesc.run();
@@ -1044,7 +1043,6 @@ namespace BALL
 
 
 	void SESComputer::run()
-		throw(Exception::GeneralException)
 	{
 		preProcessing();
 		get();
@@ -1650,7 +1648,6 @@ namespace BALL
 
 
 	bool SESSingularityCleaner::run()
-		throw(Exception::GeneralException)
 	{
 		if (!treatFirstCategory())
 		{

--- a/source/STRUCTURE/triangle.C
+++ b/source/STRUCTURE/triangle.C
@@ -81,7 +81,6 @@ namespace BALL
 
 
 	void Triangle::setPoint(Position i, TrianglePoint* vertex)
-		throw(Exception::IndexOverflow)
 	{
 		if (i > 3) {
 			throw Exception::IndexOverflow(__FILE__,__LINE__,i,2);
@@ -92,7 +91,6 @@ namespace BALL
 
 
 	TrianglePoint* Triangle::getPoint(Position i) const
-		throw(Exception::IndexOverflow)
 	{
 		if (i > 3) {
 			throw Exception::IndexOverflow(__FILE__,__LINE__,i,2);

--- a/source/STRUCTURE/trianglePoint.C
+++ b/source/STRUCTURE/trianglePoint.C
@@ -90,7 +90,6 @@ namespace BALL
 
 
 	void TrianglePoint::setNormal(const TVector3<double>& normal)
-		throw(Exception::DivisionByZero)
 	{
 		normal_ = normal;
 		normal_.normalize();

--- a/source/STRUCTURE/triangulatedSES.C
+++ b/source/STRUCTURE/triangulatedSES.C
@@ -82,7 +82,6 @@ namespace BALL
 	}
 
 	void TriangulatedSES::compute()
-		throw(Exception::GeneralException,Exception::DivisionByZero)
 	{
 		SESTriangulator sest(this);
 		sest.run();
@@ -129,7 +128,6 @@ namespace BALL
 	}
 
 	void SESTriangulator::run()
-		throw(Exception::GeneralException,Exception::DivisionByZero)
 	{
 		preProcessing();
 		triangulateToricFaces();

--- a/source/VIEW/DIALOGS/MMFF94ConfigurationDialog.C
+++ b/source/VIEW/DIALOGS/MMFF94ConfigurationDialog.C
@@ -89,7 +89,6 @@ namespace BALL
 		}
 
 		float MMFF94ConfigurationDialog::getValue_(const QLineEdit* edit) const
-			throw(Exception::InvalidFormat)
 		{
 			return ascii(edit->text()).toFloat();
 		}

--- a/source/VIEW/DIALOGS/amberConfigurationDialog.C
+++ b/source/VIEW/DIALOGS/amberConfigurationDialog.C
@@ -86,7 +86,6 @@ namespace BALL
 		}
 
 		float AmberConfigurationDialog::getValue_(const QLineEdit* edit) const
-			throw(Exception::InvalidFormat)
 		{
 			return ascii(edit->text()).toFloat();
 		}

--- a/source/VIEW/DIALOGS/assignBondOrderConfigurationDialog.C
+++ b/source/VIEW/DIALOGS/assignBondOrderConfigurationDialog.C
@@ -161,7 +161,6 @@ namespace BALL
 		}
 
 		float AssignBondOrderConfigurationDialog::getValue_(const QLineEdit* edit) const
-			throw(Exception::InvalidFormat)
 		{
 			return ascii(edit->text()).toFloat();
 		}

--- a/source/VIEW/DIALOGS/charmmConfigurationDialog.C
+++ b/source/VIEW/DIALOGS/charmmConfigurationDialog.C
@@ -217,7 +217,6 @@ namespace BALL
 		}
 
 		float CharmmConfigurationDialog::getValue_(const QLineEdit* edit) const
-			throw(Exception::InvalidFormat)
 		{
 			return ascii(edit->text()).toFloat();
 		}

--- a/source/VIEW/DIALOGS/coloringSettingsDialog.C
+++ b/source/VIEW/DIALOGS/coloringSettingsDialog.C
@@ -344,7 +344,6 @@ namespace BALL
 
 
 		ColorProcessor* ColoringSettingsDialog::createColorProcessor(ColoringMethod method) const
-			throw(Exception::InvalidOption)
 		{
 			ColorProcessor* color_processor = 0;
 

--- a/source/VIEW/DIALOGS/generateCrystalDialog.C
+++ b/source/VIEW/DIALOGS/generateCrystalDialog.C
@@ -52,7 +52,6 @@ namespace BALL
 		}
 		
 		bool GenerateCrystalDialog::initSpaceGroupList()
-		throw(Exception::FileNotFound)
 		{
 			if (generator_)
 			{

--- a/source/VIEW/DIALOGS/lightSettings.C
+++ b/source/VIEW/DIALOGS/lightSettings.C
@@ -495,24 +495,21 @@ void LightSettings::setAttenuation_(const Vector3& a)
 	 attenuation_p_3->setText(createFloatString(a.z, 4).c_str());
 }
 
-Vector3 LightSettings::getPosition_() 
-	throw(Exception::InvalidFormat)
+Vector3 LightSettings::getPosition_()
 {
 	return Vector3(position_x->text().toFloat(),
 				 			   position_y->text().toFloat(),
 			  				 position_z->text().toFloat());
 }
 
-Vector3 LightSettings::getDirection_() 
-	throw(Exception::InvalidFormat)
+Vector3 LightSettings::getDirection_()
 {
 	return Vector3(direction_x->text().toFloat(),
 				 			   direction_y->text().toFloat(),
 			  				 direction_z->text().toFloat());
 }
 
-Vector3 LightSettings::getAttenuation_() 
-	throw(Exception::InvalidFormat)
+Vector3 LightSettings::getAttenuation_()
 {
 	return Vector3(attenuation_p_1->text().toFloat(),
 				 			   attenuation_p_2->text().toFloat(),

--- a/source/VIEW/DIALOGS/modelSettingsDialog.C
+++ b/source/VIEW/DIALOGS/modelSettingsDialog.C
@@ -187,7 +187,6 @@ namespace BALL
 
 
 		ModelProcessor* ModelSettingsDialog::createModelProcessor(ModelType type) const
-			throw(Exception::InvalidOption)
 		{
 			ModelProcessor* model_processor = 0;
 

--- a/source/VIEW/DIALOGS/raytraceableContourSurfaceDialog.C
+++ b/source/VIEW/DIALOGS/raytraceableContourSurfaceDialog.C
@@ -221,7 +221,6 @@ float RaytraceableContourSurfaceDialog::getValue_(const QAbstractSlider* slider)
 
 
 float RaytraceableContourSurfaceDialog::getValue_(const QLineEdit* edit) const
-	throw(Exception::InvalidFormat)
 {
 	return (edit->text()).toFloat();
 }

--- a/source/VIEW/DIALOGS/stageSettings.C
+++ b/source/VIEW/DIALOGS/stageSettings.C
@@ -304,7 +304,6 @@ namespace BALL
 		}
 
 		Vector3 StageSettings::getTextureUpDirection_()
-			throw(Exception::InvalidFormat)
 		{
 			return Vector3(up_direction_x->text().toFloat(),
 				 			   up_direction_y->text().toFloat(),
@@ -320,7 +319,6 @@ namespace BALL
 
 
 		float StageSettings::getUser2ScreenDistance_()
-			throw(Exception::InvalidFormat)
 		{
 			return screen_distance_lineEdit->text().toFloat();
 		}
@@ -331,7 +329,6 @@ namespace BALL
 		}
 
 		float StageSettings::getUserEyeDistance_()
-			throw(Exception::InvalidFormat)
 		{
 			return eye_distance_lineEdit->text().toFloat();
 		}
@@ -342,7 +339,6 @@ namespace BALL
 		}
 		
 		float StageSettings::getUserEyeLevel_()
-			throw(Exception::InvalidFormat)
 		{
 			return eye_level_lineEdit->text().toFloat();
 		}

--- a/source/VIEW/KERNEL/modularWidget.C
+++ b/source/VIEW/KERNEL/modularWidget.C
@@ -51,7 +51,6 @@ namespace BALL
 		}
 
 		void ModularWidget::registerWidget(ModularWidget* mwidget)
-			throw(Exception::NullPointer)
 		{
 			#ifdef BALL_VIEW_DEBUG
 				Log.info() << "registering ModularWidget at " << mwidget << endl;

--- a/source/VIEW/KERNEL/serverWidget.C
+++ b/source/VIEW/KERNEL/serverWidget.C
@@ -263,8 +263,7 @@ namespace BALL
 		}
 
 	  void ServerWidget::BALLViewServer::sendObject()
-				throw(ServerWidget::NotCompositeObject)
-    {
+	{
 			output_("Server: receiving object ... \n");
 
 			unsigned long object_handle;

--- a/source/VIEW/KERNEL/stage.C
+++ b/source/VIEW/KERNEL/stage.C
@@ -114,7 +114,6 @@ namespace BALL
 		}
 
 		void Stage::Material::persistentWrite(PersistenceManager& pm, const char* name) const
-			throw(Exception::GeneralException)
 		{
 			pm.writeObjectHeader(this, name);
 				// ambient
@@ -133,7 +132,6 @@ namespace BALL
 		}
 		
 		void Stage::Material::persistentRead(PersistenceManager& pm)
-			throw(Exception::GeneralException)
 		{
 			String color;
 

--- a/source/VIEW/KERNEL/threads.C
+++ b/source/VIEW/KERNEL/threads.C
@@ -240,7 +240,6 @@ namespace BALL
 
 		// =====================================================
 		void MDSimulationThread::run()
-			throw(Exception::NullPointer)
 		{
 			if (main_control_ == 0) return;
 
@@ -392,7 +391,6 @@ namespace BALL
 		
 		/// 
 		void DockingThread::run()
-			throw(Exception::NullPointer)
 		{
 				if (dock_alg_ == 0 ||
 						main_control_ == 0)

--- a/source/VIEW/MODELS/ballAndStickModel.C
+++ b/source/VIEW/MODELS/ballAndStickModel.C
@@ -73,7 +73,6 @@ namespace BALL
 		}
 
 		void AddBallAndStickModel::setBallRadius(const float radius)
-			throw(Exception::OutOfRange)
 		{
 			// radius can never be lower or equal 0
 			if (radius <= (float)0)
@@ -85,7 +84,6 @@ namespace BALL
 		}
 
 		void AddBallAndStickModel::setStickRadius(const float radius)
-			throw(Exception::OutOfRange)
 		{
 			// radius can never be lower or equal 0
 			if (radius <= (float)0)
@@ -385,7 +383,6 @@ namespace BALL
 		}
 
 		void AddBallAndStickModel::renderDashedBond_(const Bond& bond, Vector3 n)
-			throw(Exception::DivisionByZero)
 		{
 			const Atom& a1 = *bond.getFirstAtom();
 			const Atom& a2 = *bond.getSecondAtom();

--- a/source/VIEW/RENDERING/RENDERERS/POVRenderer.C
+++ b/source/VIEW/RENDERING/RENDERERS/POVRenderer.C
@@ -52,7 +52,6 @@ namespace BALL
 
 
 		POVRenderer::POVRenderer(const String& name)
-			throw(Exception::FileNotFound)
 			: Renderer(),
 				human_readable_(true),
 				font_file_("/local/amoll/povray-3.5/include/crystal.ttf")
@@ -85,7 +84,6 @@ namespace BALL
 		}
 
 		void POVRenderer::setFileName(const String& name)
-			throw(Exception::FileNotFound)
 		{
             if (outfile_ == 0 || !RTTI::isKindOf<File>(outfile_))
 			{

--- a/source/VIEW/RENDERING/RENDERERS/STLRenderer.C
+++ b/source/VIEW/RENDERING/RENDERERS/STLRenderer.C
@@ -38,7 +38,6 @@ STLRenderer::STLRenderer()
 //the filename has to be saved as the stl file has to end with the same 
 //line as it starts just with endsolid instead "solid"
 STLRenderer::STLRenderer(const String& name)
-	throw(Exception::FileNotFound)
 	: Renderer(),
 		width(600),
 		height(600),
@@ -66,7 +65,6 @@ void STLRenderer::clear()
 }
 
 void STLRenderer::setFileName(const String& name)
-	throw(Exception::FileNotFound)
 {
 	outfile_.open(name, std::ios::out);
 	current_indent_ = 0;
@@ -1124,7 +1122,7 @@ void STLRenderer::renderMesh_(const Mesh& mesh)
 	vector<Surface::Triangle>::const_iterator itt = mesh.triangle.begin(); 
 	for (; itt != mesh.triangle.end(); itt++)
 	{
-		//header für jedes Dreieck
+		//header fï¿½r jedes Dreieck
 		outheader_("facet normal " + (VRMLVector3(mesh.normal[count])));
 		outheader_("outer loop");
 

--- a/source/VIEW/RENDERING/RENDERERS/VRMLRenderer.C
+++ b/source/VIEW/RENDERING/RENDERERS/VRMLRenderer.C
@@ -39,7 +39,6 @@ VRMLRenderer::VRMLRenderer()
 }
 
 VRMLRenderer::VRMLRenderer(const String& name)
-	throw(Exception::FileNotFound)
 	: Renderer(),
 		width(600),
 		height(600),
@@ -66,7 +65,6 @@ void VRMLRenderer::clear()
 }
 
 void VRMLRenderer::setFileName(const String& name)
-	throw(Exception::FileNotFound)
 {
 	outfile_.open(name, std::ios::out);
 	current_indent_ = 0;

--- a/source/VIEW/RENDERING/RENDERERS/XML3DRenderer.C
+++ b/source/VIEW/RENDERING/RENDERERS/XML3DRenderer.C
@@ -52,7 +52,6 @@ namespace BALL
 
 
 		XML3DRenderer::XML3DRenderer(const String& name)
-			throw(Exception::FileNotFound)
 			: Renderer(),
 				human_readable_(true),
 				create_XHTML_(true)
@@ -118,7 +117,6 @@ namespace BALL
 		}
 
 		void XML3DRenderer::setFileName(const String& name)
-			throw(Exception::FileNotFound)
 		{
 			create_XHTML_ = true;
             if (outfile_ == 0 || !RTTI::isKindOf<File>(outfile_))

--- a/source/VIEW/RENDERING/RENDERERS/raytracingRenderer.C
+++ b/source/VIEW/RENDERING/RENDERERS/raytracingRenderer.C
@@ -17,7 +17,6 @@ namespace BALL
 		Resolution RaytracingRenderer::getSupportedResolution(
 			const Resolution &min, const Resolution &max,
 			const PixelFormat &format) const
-            throw(BALL::Exception::FormatUnsupported)
 		{
 			if(!supports(format))
 			{

--- a/source/VIEW/RENDERING/glDisplayList.C
+++ b/source/VIEW/RENDERING/glDisplayList.C
@@ -92,8 +92,6 @@ namespace BALL
 		}
 
 		void GLDisplayList::startDefinition()
-			throw(GLDisplayList::NestedDisplayList, GLDisplayList::NoDisplayListAvailable, 
-						GLDisplayList::DisplayListRedeclaration)
 		{
 			CHECK_GL_ERROR
 			if (GL_list_ != 0)

--- a/source/VIEW/RENDERING/renderWindow.C
+++ b/source/VIEW/RENDERING/renderWindow.C
@@ -29,7 +29,7 @@ namespace BALL
 			}
 
 		template<typename taPixelDatatype>
-			FrameBufferPtr TRenderWindow<taPixelDatatype>::getBuffer() throw(BALL::Exception::NoBufferAvailable)        
+			FrameBufferPtr TRenderWindow<taPixelDatatype>::getBuffer()
 			{
 				if((m_fmt.getWidth() < m_minimalWidth) || (m_fmt.getHeight() < m_minimalHeight))
 				{


### PR DESCRIPTION
This patch removes all exception specifications (`throw(something)`) from BALL and VIEW. Exception specifications have been removed from the C++ standard a long time ago and cause a gazillion warnings.
@anhi and @philthiel: Any objections?