### PR TITLE
Disable Qt keywords to prevent name clashes with other deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ FIND_PACKAGE(Qt5 ${QT_MIN_VERSION} REQUIRED Core Network Xml)
 LIST(APPEND BALL_DEP_LIBRARIES Qt5::Core
                                Qt5::Network
                                Qt5::Xml)
+LIST(APPEND BALL_PROJECT_COMPILE_DEFNS "-DQT_NO_KEYWORDS")
 
 IF (BALL_HAS_VIEW)
 	FIND_PACKAGE(Qt5 ${QT_MIN_VERSION} REQUIRED OpenGL PrintSupport Test Widgets)

--- a/doc/TUTORIAL/view.tex
+++ b/doc/TUTORIAL/view.tex
@@ -185,7 +185,7 @@ class BALL_VIEW_EXPORT LabelDialog
   // Overloaded from ModularWidget
   virtual void checkMenu(MainControl& main_control);
 	
-  protected slots:
+  protected Q_SLOTS:
   virtual void accept();
   virtual void editColor();
   virtual void addTag();

--- a/include/BALL/SYSTEM/simpleDownloader.h
+++ b/include/BALL/SYSTEM/simpleDownloader.h
@@ -201,7 +201,7 @@ namespace BALL
 				BasicHelper(HelperThread* caller, QNetworkReply* reply);
 				virtual ~BasicHelper(){}
 
-			public slots:
+			public Q_SLOTS:
 				void error(QNetworkReply::NetworkError error);
 #ifndef QT_NO_SSL
 				void sslErrors(const QList<QSslError>& errors);
@@ -220,7 +220,7 @@ namespace BALL
 			public:
 				DLArrayHelper(HelperThread* caller, QNetworkReply* reply, QByteArray* result);
 
-			public slots:
+			public Q_SLOTS:
 				void finished();
 
 			private:
@@ -234,7 +234,7 @@ namespace BALL
 			public:
 				DLHelper(HelperThread* caller, QNetworkReply* reply, const String& path);
 
-			public slots:
+			public Q_SLOTS:
 				void finished();
 				void receivedData();
 

--- a/include/BALL/VIEW/DATATYPE/dataset.h
+++ b/include/BALL/VIEW/DATATYPE/dataset.h
@@ -282,7 +282,7 @@ namespace BALL
 			*/
 			vector<String> getSupportedFileFormats() { return file_formats_;}
 
-			public slots:
+			public Q_SLOTS:
 
 			/// Show a file dialog for writing the selected Dataset.
 			virtual bool write();

--- a/include/BALL/VIEW/DATATYPE/standardDatasets.h
+++ b/include/BALL/VIEW/DATATYPE/standardDatasets.h
@@ -107,7 +107,7 @@ class BALL_VIEW_EXPORT RegularData3DController
 
 	static String type;
 
-	public slots:
+	public Q_SLOTS:
 
 	///
 	bool createVectorGrid();
@@ -178,7 +178,7 @@ class BALL_VIEW_EXPORT TrajectoryController
 
 	static String type;
 
-	public slots:
+	public Q_SLOTS:
 
 	///
 	bool visualizeTrajectory();
@@ -233,7 +233,7 @@ class BALL_VIEW_EXPORT DockResultController
 
 	static String type;
 
-	public slots:
+	public Q_SLOTS:
 
 	///
 	void showDockResult();
@@ -289,7 +289,7 @@ class BALL_VIEW_EXPORT VectorGridController
 
 	static String type;
 
-	public slots:
+	public Q_SLOTS:
 
 	///
 	bool visualizeFieldLines();
@@ -339,7 +339,7 @@ class BALL_VIEW_EXPORT RaytraceableGridController
 
 	static String type;
 
-	public slots:
+	public Q_SLOTS:
 	
 	///
 	void  visualizeRaytraceableContourSurface();

--- a/include/BALL/VIEW/DIALOGS/FDPBDialog.h
+++ b/include/BALL/VIEW/DIALOGS/FDPBDialog.h
@@ -83,7 +83,7 @@ namespace BALL
 				{ return system_;}
 			
 
-		public slots:
+		public Q_SLOTS:
 
 			///
 			virtual void browseChargesData();
@@ -103,7 +103,7 @@ namespace BALL
 			///
 			virtual void resetPressed();
 
-		protected slots:
+		protected Q_SLOTS:
 			virtual void clicked(QAbstractButton* button);
 
 		protected:

--- a/include/BALL/VIEW/DIALOGS/MMFF94ConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/MMFF94ConfigurationDialog.h
@@ -43,7 +43,7 @@ namespace BALL
 			/// Destructor
 			virtual ~MMFF94ConfigurationDialog();
 			
-			public slots:
+			public Q_SLOTS:
 
 			///
 			virtual void resetOptions();
@@ -57,7 +57,7 @@ namespace BALL
 			/// apply the settings to a given MMFF94 force field
 			void applyTo(MMFF94& mmff);
 
-			protected slots:
+			protected Q_SLOTS:
 
 			virtual void browseParameterFiles();
 

--- a/include/BALL/VIEW/DIALOGS/PTEDialog.h
+++ b/include/BALL/VIEW/DIALOGS/PTEDialog.h
@@ -35,12 +35,12 @@ class BALL_VIEW_EXPORT PTEDialog
 	///
 	~PTEDialog();
 	
-	public slots:
+	public Q_SLOTS:
 		
 	///
 	void newElementType(int elementNumber);
 
-	protected slots:
+	protected Q_SLOTS:
 
 	void elementClicked_();
 	void elementChoosen_();

--- a/include/BALL/VIEW/DIALOGS/amberConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/amberConfigurationDialog.h
@@ -43,7 +43,7 @@ namespace BALL
 			/// Destructor
 			virtual ~AmberConfigurationDialog();
 			
-			public slots:
+			public Q_SLOTS:
 
 			///
 			void accept();
@@ -60,7 +60,7 @@ namespace BALL
 			//_
 			void periodicBoundaryClicked();
 
-			protected slots:
+			protected Q_SLOTS:
 
 			virtual void browseParameterFiles();
 

--- a/include/BALL/VIEW/DIALOGS/assignBondOrderConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/assignBondOrderConfigurationDialog.h
@@ -55,7 +55,7 @@ namespace BALL
 			///
 			virtual void initializeWidget(MainControl& main_control);
 
-			public slots:
+			public Q_SLOTS:
 
 			///
 			virtual void resetOptions();
@@ -66,7 +66,7 @@ namespace BALL
 			///
 			void reject();
 
-			protected slots:
+			protected Q_SLOTS:
 
 				virtual void browseParameterFiles_();
 				virtual void balanceParameterChanged_();

--- a/include/BALL/VIEW/DIALOGS/assignBondOrderResultsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/assignBondOrderResultsDialog.h
@@ -51,7 +51,7 @@ namespace BALL
 					///
 					void setProcessor(AssignBondOrderProcessor* abop);
 
-				public slots:
+				public Q_SLOTS:
 					
 					/// Show and raise dialog
 					void show();

--- a/include/BALL/VIEW/DIALOGS/atomOverview.h
+++ b/include/BALL/VIEW/DIALOGS/atomOverview.h
@@ -142,7 +142,7 @@ namespace BALL
 			*/
 			//@{
 				
-			protected slots:
+			protected Q_SLOTS:
 							
 			/** Indicates the apply button was pressed.
 			 		Creates a new Representation with the Label and notifies the widgets.

--- a/include/BALL/VIEW/DIALOGS/bondProperties.h
+++ b/include/BALL/VIEW/DIALOGS/bondProperties.h
@@ -33,7 +33,7 @@ namespace BALL
 										 bool modal = false, Qt::WindowFlags fl = 0 );
 			~BondProperties();
 
-		public slots:
+		public Q_SLOTS:
 			void bondSelected();
 			void focusAtom();
 			void focusPartner();

--- a/include/BALL/VIEW/DIALOGS/charmmConfigurationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/charmmConfigurationDialog.h
@@ -46,7 +46,7 @@ namespace BALL
 			///
 			const String& getFilename() const;
 			
-			public slots:
+			public Q_SLOTS:
 
 			virtual void resetOptions();
 			
@@ -65,7 +65,7 @@ namespace BALL
 			//_
 			void periodicBoundaryClicked();
 
-			protected slots:
+			protected Q_SLOTS:
 
 			virtual void browseParameterFiles();
 

--- a/include/BALL/VIEW/DIALOGS/clippingDialog.h
+++ b/include/BALL/VIEW/DIALOGS/clippingDialog.h
@@ -57,7 +57,7 @@ namespace BALL
 			
 			//@}
 			
-			public slots:
+			public Q_SLOTS:
 				
   		/** @name Public slots
 	  	*/

--- a/include/BALL/VIEW/DIALOGS/coloringSettingsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/coloringSettingsDialog.h
@@ -74,7 +74,7 @@ namespace BALL
 			///
 			virtual void readPreferenceEntries(INIFile& inifile);
 
-			protected slots:
+			protected Q_SLOTS:
 
 			virtual void maxDistanceChanged();
 			virtual void maxTFChanged();

--- a/include/BALL/VIEW/DIALOGS/compositeProperties.h
+++ b/include/BALL/VIEW/DIALOGS/compositeProperties.h
@@ -36,7 +36,7 @@ namespace BALL
 													bool modal = false, Qt::WindowFlags fl = 0 );
 			~CompositeProperties();
 
-		public slots:
+		public Q_SLOTS:
 			void accept();
 
 		private:

--- a/include/BALL/VIEW/DIALOGS/contourSurfaceDialog.h
+++ b/include/BALL/VIEW/DIALOGS/contourSurfaceDialog.h
@@ -40,10 +40,10 @@ class BALL_VIEW_EXPORT ContourSurfaceDialog
 		void setController(DatasetController* controller) {controller_ = controller;}
 		ColorRGBA getColor();
 
-	public slots:
+	public Q_SLOTS:
 		virtual int exec();
 
-	protected slots: 
+	protected Q_SLOTS:
 		virtual void valuesChanged();
 		virtual void chooseColor();
 	

--- a/include/BALL/VIEW/DIALOGS/displayProperties.h
+++ b/include/BALL/VIEW/DIALOGS/displayProperties.h
@@ -161,7 +161,7 @@ namespace BALL
 			///
 			void setColoringSettingsDialog(ColoringSettingsDialog* dialog);
 	
-			public slots:
+			public Q_SLOTS:
 					
 			//@} 
 			/** @name Public slots 

--- a/include/BALL/VIEW/DIALOGS/dockDialog.h
+++ b/include/BALL/VIEW/DIALOGS/dockDialog.h
@@ -163,7 +163,7 @@ namespace BALL
 				void reset();
 				//@}
 					
-			public slots:
+			public Q_SLOTS:
 	
 				/** Shows and raises the dialog.
 					* Dialog is adapted for docking / redocking.

--- a/include/BALL/VIEW/DIALOGS/dockProgressDialog.h
+++ b/include/BALL/VIEW/DIALOGS/dockProgressDialog.h
@@ -80,7 +80,7 @@ namespace BALL
 				void fillDialog(const QString& p1, const QString& p2, const QString& alg, const QString& sf, const Options& alg_opt, const Options& sf_opt);
 				//@}
 				
-			public slots:
+			public Q_SLOTS:
 			
 				/** Starts timer and shows dialog to user.
 					*/
@@ -99,7 +99,7 @@ namespace BALL
 				void abortClicked();
 				
 				
-			protected slots:
+			protected Q_SLOTS:
 			
 				/** Is called when timer elapses.
 					* Gets current progress of docking algorithm.

--- a/include/BALL/VIEW/DIALOGS/dockResultDialog.h
+++ b/include/BALL/VIEW/DIALOGS/dockResultDialog.h
@@ -81,7 +81,7 @@ namespace BALL
 				void addScoringFunction(const QString& name, DockingController::ScoringFunction score_func, QDialog* dialog=0);
 				//@}
 					
-			public slots:
+			public Q_SLOTS:
 
 				/** Shows and raises result dialog.
 					* Fills the result table in the dialog with the values stored in \link DockResultDialog::dock_res_ dock_res_ \endlink .
@@ -137,7 +137,7 @@ namespace BALL
 				void closeClicked();
 				
 				
-				protected slots:
+				protected Q_SLOTS:
 
 				void selectionChanged_();
 			

--- a/include/BALL/VIEW/DIALOGS/downloadElectronDensity.h
+++ b/include/BALL/VIEW/DIALOGS/downloadElectronDensity.h
@@ -80,7 +80,7 @@ namespace BALL
 				///
 				void checkMenu(MainControl& mc);
 			
-			public slots:
+			public Q_SLOTS:
 
 				///
 				void slotDownload();

--- a/include/BALL/VIEW/DIALOGS/downloadPDBFile.h
+++ b/include/BALL/VIEW/DIALOGS/downloadPDBFile.h
@@ -69,7 +69,7 @@ namespace BALL
 				///
 				void checkMenu(MainControl& mc);
 
-			public slots:
+			public Q_SLOTS:
 
 				///
 				void slotDownload();

--- a/include/BALL/VIEW/DIALOGS/editSingleShortcut.h
+++ b/include/BALL/VIEW/DIALOGS/editSingleShortcut.h
@@ -50,11 +50,11 @@ namespace BALL
 				void reset();
 				void setup(const QString& shortcut);
 
-			public slots:
+			public Q_SLOTS:
 				virtual void accept();
 				virtual void reject();
 
-			protected slots:
+			protected Q_SLOTS:
 				void modeChanged_(bool toggled);
 
 			protected:

--- a/include/BALL/VIEW/DIALOGS/exportGeometryDialog.h
+++ b/include/BALL/VIEW/DIALOGS/exportGeometryDialog.h
@@ -63,7 +63,7 @@ namespace BALL
 
 			bool basestats[100];
 
-			public slots:
+			public Q_SLOTS:
 
 			/** Show and raise the dialog
 			*/
@@ -77,7 +77,7 @@ namespace BALL
 			*/
 			//@{
 
-			protected slots:
+			protected Q_SLOTS:
 
 			/**	Opens the file decision dialog
 			*/

--- a/include/BALL/VIEW/DIALOGS/fieldLinesDialog.h
+++ b/include/BALL/VIEW/DIALOGS/fieldLinesDialog.h
@@ -47,7 +47,7 @@ namespace BALL
 			Size getIcosaederInterplationSteps();
 			float getAtomsDistance();
 
-			public slots:
+			public Q_SLOTS:
 
 			void accept();
 		};

--- a/include/BALL/VIEW/DIALOGS/generateCrystalDialog.h
+++ b/include/BALL/VIEW/DIALOGS/generateCrystalDialog.h
@@ -73,7 +73,7 @@ namespace BALL
 				///
 				//virtual void initializeWidget(MainControl& main_control);
 				
-			public slots:
+			public Q_SLOTS:
 				
 				///
 				void slotOk();

--- a/include/BALL/VIEW/DIALOGS/geometricFitDialog.h
+++ b/include/BALL/VIEW/DIALOGS/geometricFitDialog.h
@@ -97,7 +97,7 @@ namespace BALL
 					
 				//@}
 					
-			public slots:
+			public Q_SLOTS:
 				
 				/** Shows dialog to user.
 					*/

--- a/include/BALL/VIEW/DIALOGS/gridVisualizationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/gridVisualizationDialog.h
@@ -60,7 +60,7 @@ namespace BALL
 			///
 			void setMidValue(float value);
 
-			public slots:
+			public Q_SLOTS:
 			
 			void accept();
 			void autoScale();

--- a/include/BALL/VIEW/DIALOGS/labelDialog.h
+++ b/include/BALL/VIEW/DIALOGS/labelDialog.h
@@ -108,7 +108,7 @@ namespace BALL
 			
 			//@}
 			
-			public slots:
+			public Q_SLOTS:
 				
   		/** @name Public slots
 	  	*/
@@ -123,7 +123,7 @@ namespace BALL
 			*/
 			//@{
 				
-			protected slots:
+			protected Q_SLOTS:
 							
 			/** Indicates the apply button was pressed.
 			 		Creates a new Representation with the Label and notifies the widgets.

--- a/include/BALL/VIEW/DIALOGS/lightSettings.h
+++ b/include/BALL/VIEW/DIALOGS/lightSettings.h
@@ -69,7 +69,7 @@ namespace BALL
 			///
 			void restoreValues(bool all);
 			
-			public slots:
+			public Q_SLOTS:
 
 			/// Slot for the AddLight button
 	    virtual void addLightPressed();

--- a/include/BALL/VIEW/DIALOGS/mainControlPreferences.h
+++ b/include/BALL/VIEW/DIALOGS/mainControlPreferences.h
@@ -80,7 +80,7 @@ class BALL_VIEW_EXPORT MainControlPreferences
 	///
 	void readPreferenceEntries(const INIFile& inifile);
 
-	public slots:
+	public Q_SLOTS:
 
 	/// Get the application's default font
 	void selectFont();

--- a/include/BALL/VIEW/DIALOGS/materialSettings.h
+++ b/include/BALL/VIEW/DIALOGS/materialSettings.h
@@ -57,7 +57,7 @@ namespace BALL
 			 */
 			void updateDefaultMaterialsFromStage();
 
-			public slots:
+			public Q_SLOTS:
 
 			virtual void ambientFactorChanged();
 			virtual void specularityFactorChanged();

--- a/include/BALL/VIEW/DIALOGS/minimizationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/minimizationDialog.h
@@ -102,7 +102,7 @@ namespace BALL
 				/// Return the ID of the selected forcefield (see enum values in MolecularStructure)
 				Position selectedForceField() const;
 				
-				public slots:
+				public Q_SLOTS:
 
 				///
 				virtual void accept();

--- a/include/BALL/VIEW/DIALOGS/modelSettingsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/modelSettingsDialog.h
@@ -227,11 +227,11 @@ namespace BALL
 			void setCartoonDNABaseRadius(float value)
 				{ setValue_(cartoon_dna_base_radius_slider, value / 10.);}
 
-			public slots:
+			public Q_SLOTS:
 			
 			///
 
-			protected slots:
+			protected Q_SLOTS:
 			void stickRadiusChanged() {setLabelText_(stick_radius_label, stick_radius_slider);}
 			void VDWfactorChanged() {setLabelText_(vdw_radius_factor_label, vdw_radius_factor_slider);}
 			void ballStickSphereRadiusChanged() {setLabelText_(ball_stick_sphere_radius_label, ball_stick_sphere_radius_slider);}

--- a/include/BALL/VIEW/DIALOGS/modifyRepresentationDialog.h
+++ b/include/BALL/VIEW/DIALOGS/modifyRepresentationDialog.h
@@ -90,7 +90,7 @@ namespace BALL
 			///
 			void setMode(Position pos);
 				
-			public slots:
+			public Q_SLOTS:
 			
 			void accept();
 			void tabChanged();		
@@ -100,7 +100,7 @@ namespace BALL
 			void show();
 			void applySplit();
 
-			protected slots:
+			protected Q_SLOTS:
 
 			void customColorTransparencyChanged();
 			void changeDrawingModeTransparencyChanged();

--- a/include/BALL/VIEW/DIALOGS/molecularDynamicsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/molecularDynamicsDialog.h
@@ -92,12 +92,12 @@ class BALL_VIEW_EXPORT MolecularDynamicsDialog
 		/// Return the ID of the selected forcefield (see enum values in MolecularStructure)
 		Position selectedForceField() const;
 
-		public slots:
+		public Q_SLOTS:
 				
 		///
 		virtual void accept();
 
-		protected slots:
+		protected Q_SLOTS:
 
 		virtual void enableDCDFileSelected();
 		

--- a/include/BALL/VIEW/DIALOGS/molecularFileDialog.h
+++ b/include/BALL/VIEW/DIALOGS/molecularFileDialog.h
@@ -183,7 +183,7 @@ namespace BALL
 
 			void setReadPDBModels(bool read) { read_all_pdb_models_ = read; }
 
-			public slots:
+			public Q_SLOTS:
 
 			/** Open a molecular file.
 					This method tries to open and read a molecular file, selected from a QFileDialog,

--- a/include/BALL/VIEW/DIALOGS/networkPreferences.h
+++ b/include/BALL/VIEW/DIALOGS/networkPreferences.h
@@ -50,7 +50,7 @@ namespace BALL
 				///
 				bool proxyEnabled();
 
-				public slots:
+				public Q_SLOTS:
 
 				///
 				void proxyModeChanged(int proxy_mode);

--- a/include/BALL/VIEW/DIALOGS/peptideDialog.h
+++ b/include/BALL/VIEW/DIALOGS/peptideDialog.h
@@ -43,7 +43,7 @@ namespace BALL
 			///
 			Protein* getProtein() { return protein_;}
 
-			public slots:
+			public Q_SLOTS:
 
 			///
 			void ala_pressed() {insert_('a');}

--- a/include/BALL/VIEW/DIALOGS/pluginDialog.h
+++ b/include/BALL/VIEW/DIALOGS/pluginDialog.h
@@ -118,7 +118,7 @@ namespace BALL
 				 */
 				virtual void setDefaultPluginDirectory();
 
-			protected slots:
+			protected Q_SLOTS:
 				virtual void addPluginDirectory();
 				virtual void removePluginDirectory();
 				virtual void directorySelectionChanged(const QModelIndex&, const QModelIndex& /* previous */);

--- a/include/BALL/VIEW/DIALOGS/preferences.h
+++ b/include/BALL/VIEW/DIALOGS/preferences.h
@@ -119,10 +119,10 @@ namespace BALL
 			/// Activate or deactivate the apply and ok buttons
 			void setApplyEnabled(bool enabled);
 
-			signals:
+			Q_SIGNALS:
 				void applied();
 
-			public slots:
+			public Q_SLOTS:
 
 			//@}
 			/** @name Public slots
@@ -151,7 +151,7 @@ namespace BALL
 			/// @deprecated Help system has been removed. This function will also be removed in the next release.
 			BALL_DEPRECATED void showHelp();
 
-			protected slots:
+			protected Q_SLOTS:
 				void dialogButtonsClicked_(QAbstractButton* button);
 
 			protected:

--- a/include/BALL/VIEW/DIALOGS/pubchemDialog.h
+++ b/include/BALL/VIEW/DIALOGS/pubchemDialog.h
@@ -62,7 +62,7 @@ namespace BALL
 
 				///
 				void generateFromSMILES ( const String& SMILES );
-			public slots:
+			public Q_SLOTS:
 
 				/// Show and raise dialog
 				void show();

--- a/include/BALL/VIEW/DIALOGS/pythonSettings.h
+++ b/include/BALL/VIEW/DIALOGS/pythonSettings.h
@@ -67,7 +67,7 @@ namespace BALL
 			///
 			void readPreferenceEntries(const INIFile& inifile);
 
-			public slots:
+			public Q_SLOTS:
 
 			/// Open a filedialog to select the startup script
 			void fileSelected();

--- a/include/BALL/VIEW/DIALOGS/raytraceableContourSurfaceDialog.h
+++ b/include/BALL/VIEW/DIALOGS/raytraceableContourSurfaceDialog.h
@@ -53,7 +53,7 @@ class BALL_VIEW_EXPORT RaytraceableContourSurfaceDialog
 	void setGrid(RaytraceableGrid* grid) {grid_ = grid;};
 	RaytraceableGrid* getGrid() {return grid_;};
 
-	public slots:
+	public Q_SLOTS:
 	
 	///
 	void add();
@@ -82,7 +82,7 @@ class BALL_VIEW_EXPORT RaytraceableContourSurfaceDialog
 
 	//void setDefaultRangeValues_();
 	
-	protected slots:
+	protected Q_SLOTS:
 
 	void setDefaultRangeValues_();
 

--- a/include/BALL/VIEW/DIALOGS/setCamera.h
+++ b/include/BALL/VIEW/DIALOGS/setCamera.h
@@ -34,7 +34,7 @@ namespace BALL
 
 				Camera* camera;
 						
-			public slots:
+			public Q_SLOTS:
 				void okPressed();
 		};
 

--- a/include/BALL/VIEW/DIALOGS/setClippingPlane.h
+++ b/include/BALL/VIEW/DIALOGS/setClippingPlane.h
@@ -36,7 +36,7 @@ namespace BALL
 
 				ClippingPlane* plane_;
 						
-			public slots:
+			public Q_SLOTS:
 				void okPressed();
 		};
 

--- a/include/BALL/VIEW/DIALOGS/shortcutDialog.h
+++ b/include/BALL/VIEW/DIALOGS/shortcutDialog.h
@@ -55,10 +55,10 @@ namespace BALL
 			*/
 			virtual void initializeWidget(MainControl& main_control);
 
-			public slots:
+			public Q_SLOTS:
 				virtual void searchTextChanged(QString filter);
 
-			protected slots:
+			protected Q_SLOTS:
 				virtual void browseImportFile_();
 				virtual void browseExportFile_();
 

--- a/include/BALL/VIEW/DIALOGS/snapShotVisualisation.h
+++ b/include/BALL/VIEW/DIALOGS/snapShotVisualisation.h
@@ -54,7 +54,7 @@ class BALL_VIEW_EXPORT SnapshotVisualisationDialog
 	///
 	Size getEndSnapshot() const;
 	
-	public slots:
+	public Q_SLOTS:
 
 	///
 	void show();
@@ -107,7 +107,7 @@ class BALL_VIEW_EXPORT SnapshotVisualisationDialog
 	///
 	void cancelPressed();
 	
-	protected slots:
+	protected Q_SLOTS:
 
 	void sliderDragStarted_();
 	void sliderDragEnded_();

--- a/include/BALL/VIEW/DIALOGS/stageSettings.h
+++ b/include/BALL/VIEW/DIALOGS/stageSettings.h
@@ -105,7 +105,7 @@ namespace BALL
 
 			virtual bool setValueAllowed(QObject* widget);
 
-			public slots:
+			public Q_SLOTS:
 
 			///
 			void computeDefaultPressed();
@@ -131,7 +131,7 @@ namespace BALL
 			///
 			void stereoModeChanged();
 
-			private slots:
+			private Q_SLOTS:
 				
 			///
 			void eyeDistanceChanged();

--- a/include/BALL/VIEW/DIALOGS/stereoSettingsDialog.h
+++ b/include/BALL/VIEW/DIALOGS/stereoSettingsDialog.h
@@ -43,7 +43,7 @@ namespace BALL
 				*/
 				virtual void initializeWidget(MainControl& main_control);
 						
-			public slots:
+			public Q_SLOTS:
 				void okPressed();
 				virtual void apply();
 				virtual void show();

--- a/include/BALL/VIEW/DIALOGS/undoManagerDialog.h
+++ b/include/BALL/VIEW/DIALOGS/undoManagerDialog.h
@@ -54,7 +54,7 @@ namespace BALL
 				/// Overrides message in order to intercept system changed events
 				virtual void onNotify(Message* message);
 
-			public slots:
+			public Q_SLOTS:
 
 				/// Show and raise dialog
 				void show();

--- a/include/BALL/VIEW/KERNEL/MODES/editMode.h
+++ b/include/BALL/VIEW/KERNEL/MODES/editMode.h
@@ -39,7 +39,7 @@ namespace BALL
 				virtual void activate();
 				virtual void populateContextMenu(QMenu* menu);
 
-			protected slots:
+			protected Q_SLOTS:
 				virtual void addStructure_();
 				virtual void setFormalCharge_();
 				virtual void changeBondOrder_();

--- a/include/BALL/VIEW/KERNEL/MODES/interactionMode.h
+++ b/include/BALL/VIEW/KERNEL/MODES/interactionMode.h
@@ -55,9 +55,9 @@ namespace BALL
 				bool isCurrent() const { return is_current_; }
 				void setCurrent(bool current) { is_current_ = current; }
 
-			signals:
+			Q_SIGNALS:
 				void requestModeChange(InteractionMode* mode);
-			protected slots:
+			protected Q_SLOTS:
 				void modeChangeSlot_();
 
 			protected:

--- a/include/BALL/VIEW/KERNEL/MODES/interactionModeManager.h
+++ b/include/BALL/VIEW/KERNEL/MODES/interactionModeManager.h
@@ -50,7 +50,7 @@ namespace BALL
 
 				void switchToLastMode();
 
-			protected slots:
+			protected Q_SLOTS:
 				void setMode_(InteractionMode* new_mode);
 
 			protected:

--- a/include/BALL/VIEW/KERNEL/MODES/moveMode.h
+++ b/include/BALL/VIEW/KERNEL/MODES/moveMode.h
@@ -21,7 +21,7 @@ namespace BALL
 				virtual void activate();
 				virtual void populateContextMenu(QMenu* menu);
 
-			protected slots:
+			protected Q_SLOTS:
 				void moveAtomTriggered_();
 
 			protected:

--- a/include/BALL/VIEW/KERNEL/mainControl.h
+++ b/include/BALL/VIEW/KERNEL/mainControl.h
@@ -727,7 +727,7 @@ namespace BALL
 			*/
 			//@{
 			
-			public slots:
+			public Q_SLOTS:
 
 			/**	Initialize all registered ModularWidget objects.
 					It initializes the menu structure, the preferences dialogs and connects
@@ -822,7 +822,7 @@ namespace BALL
 
 			//@}
 			
-			protected slots:
+			protected Q_SLOTS:
 
 			/*_ This slot is called internally whenever the apply button
 					of the Preferences dialog	is pressed.

--- a/include/BALL/VIEW/KERNEL/serverWidget.h
+++ b/include/BALL/VIEW/KERNEL/serverWidget.h
@@ -298,10 +298,10 @@ namespace BALL
 			/** @name Signals and Slots
 			 */
 			//@{
-			public slots:
+			public Q_SLOTS:
 				void handleLocking(bool lock);
 
-			signals:
+			Q_SIGNALS:
 				void lockRequested(bool lock);
 
 			//@}

--- a/include/BALL/VIEW/KERNEL/shortcutRegistry.h
+++ b/include/BALL/VIEW/KERNEL/shortcutRegistry.h
@@ -82,7 +82,7 @@ namespace BALL
 				virtual bool getValue(String&) const;
 				virtual bool setValue(const String&);
 
-			signals:
+			Q_SIGNALS:
 				void shortcutChanged();
 
 			protected:

--- a/include/BALL/VIEW/WIDGETS/HTMLPage.h
+++ b/include/BALL/VIEW/WIDGETS/HTMLPage.h
@@ -17,14 +17,14 @@ namespace BALL
 			public:
 				virtual QString getName() const = 0;
 
-			public slots:
+			public Q_SLOTS:
 
 				void execute(const QList<QPair<QString, QString> >& parameters);
 
 			protected:
 				virtual void executeImpl_(const QList<QPair<QString, QString> >& parameters) = 0;
 
-			signals:
+			Q_SIGNALS:
 				void finishedExecution();
 		};
 

--- a/include/BALL/VIEW/WIDGETS/SDWidget.h
+++ b/include/BALL/VIEW/WIDGETS/SDWidget.h
@@ -82,7 +82,7 @@ namespace BALL
 
 				QSize sizeHint() const;
 
-			protected slots:
+			protected Q_SLOTS:
 				void exportImage_();
 
 			protected:

--- a/include/BALL/VIEW/WIDGETS/colorButton.h
+++ b/include/BALL/VIEW/WIDGETS/colorButton.h
@@ -44,10 +44,10 @@ namespace BALL
 
 				QSize sizeHint() const;
 
-			public slots:
+			public Q_SLOTS:
 				void chooseColor();
 
-			signals:
+			Q_SIGNALS:
 				void colorChanged(QColor color);
 
 			protected:

--- a/include/BALL/VIEW/WIDGETS/colorTable.h
+++ b/include/BALL/VIEW/WIDGETS/colorTable.h
@@ -51,7 +51,7 @@ namespace BALL
 				///
 				virtual bool setValue(const String& value);
 
-			private slots:
+			private Q_SLOTS:
 
 				void beginEdit(int row, int col);
 

--- a/include/BALL/VIEW/WIDGETS/datasetControl.h
+++ b/include/BALL/VIEW/WIDGETS/datasetControl.h
@@ -114,12 +114,12 @@ namespace BALL
 			/// Deletes the currently selected items
 			virtual void deleteCurrentItems();
 
-			public slots:
+			public Q_SLOTS:
 				
 			// Overloaded from GenericControl 
 //   			virtual void deleteCurrentItems();
 
-		  protected slots:
+			protected Q_SLOTS:
 
 			virtual void showGuestContextMenu(const QPoint& pos);
 			

--- a/include/BALL/VIEW/WIDGETS/dockWidget.h
+++ b/include/BALL/VIEW/WIDGETS/dockWidget.h
@@ -63,7 +63,7 @@ namespace BALL
 			///
 			QGridLayout* getGuestLayout() { return layout_;}
 
-			public slots:
+			public Q_SLOTS:
 
 			///
 			virtual void dropEvent(QDropEvent* e);

--- a/include/BALL/VIEW/WIDGETS/dockingController.h
+++ b/include/BALL/VIEW/WIDGETS/dockingController.h
@@ -144,7 +144,7 @@ namespace BALL
 				///
 				virtual EnergeticEvaluation* createEvaluationMethod(Index method);
 
-			public slots:
+			public Q_SLOTS:
 				
 				/** Is called when docking is started by clicking on menu entry	<b> Docking </b>.
 						Calls \link DockingController::runDocking runDocking(false) \endlink.

--- a/include/BALL/VIEW/WIDGETS/fileObserver.h
+++ b/include/BALL/VIEW/WIDGETS/fileObserver.h
@@ -61,7 +61,7 @@ namespace BALL
 			/// Set the update interval in milli seconds
 			void setUpdateInterval(Size msec);
 
-			public slots:
+			public Q_SLOTS:
 
 			/// Look for updates in the file
 			void updateFile();

--- a/include/BALL/VIEW/WIDGETS/genericControl.h
+++ b/include/BALL/VIEW/WIDGETS/genericControl.h
@@ -108,12 +108,12 @@ namespace BALL
 
 			//@}
 
-			public slots:
+			public Q_SLOTS:
 			
 			/// Called by if del is pressed
  			virtual void deleteCurrentItems(){};
 
-		  protected slots:
+			protected Q_SLOTS:
 
  			virtual void deselectOtherControls_();
 

--- a/include/BALL/VIEW/WIDGETS/geometricControl.h
+++ b/include/BALL/VIEW/WIDGETS/geometricControl.h
@@ -122,10 +122,10 @@ namespace BALL
 
 			void updateClippingPlanes();
 
-			public slots:
+			public Q_SLOTS:
 				
 			//@}
-			/** @name Public slots 
+			/** @name Public slots
 			*/ 
 			//@{
 			
@@ -186,7 +186,7 @@ namespace BALL
 			///
 			ModifyRepresentationDialog* getModifySurfaceDialog();
 
-		  protected slots:
+		  protected Q_SLOTS:
 			
 			//@} 
 			///** @name Protected members */ 
@@ -207,7 +207,7 @@ namespace BALL
 
 			//@}
 			
-		  protected slots:
+		  protected Q_SLOTS:
 
 			virtual void onItemClicked(QTreeWidgetItem* item, int col);
 			void showGuestContextMenu(const QPoint& pos);

--- a/include/BALL/VIEW/WIDGETS/gridColorWidget.h
+++ b/include/BALL/VIEW/WIDGETS/gridColorWidget.h
@@ -38,10 +38,10 @@ namespace BALL
 
 				int getNumLevels() const;
 
-			signals:
+			Q_SIGNALS:
 				void autoScaleRequested();
 
-			protected slots:
+			protected Q_SLOTS:
 				void transparencyToggled(bool enabled);
 				void normalizationToggled(bool enabled);
 				void validateText(QString str);

--- a/include/BALL/VIEW/WIDGETS/helpViewer.h
+++ b/include/BALL/VIEW/WIDGETS/helpViewer.h
@@ -137,7 +137,7 @@ namespace BALL
 			///
 			void showDocumentationFor(const String& classname, const String& member);
 					
-			public slots:
+			public Q_SLOTS:
 
 			/// Show default page
 			virtual void showHelp();

--- a/include/BALL/VIEW/WIDGETS/hotkeyTable.h
+++ b/include/BALL/VIEW/WIDGETS/hotkeyTable.h
@@ -75,7 +75,7 @@ namespace BALL
 				///
 				void setContent(const std::list<Hotkey>& hotkeys);
 
-			public slots:
+			public Q_SLOTS:
 
 				///
 				virtual void addEmptyRow();

--- a/include/BALL/VIEW/WIDGETS/logView.h
+++ b/include/BALL/VIEW/WIDGETS/logView.h
@@ -26,7 +26,7 @@ namespace BALL
 
 			DragLogView(QWidget* parent);
 
-			public slots:
+			public Q_SLOTS:
 			virtual void contentsDragEnterEvent(QDragEnterEvent* e);
 			virtual void contentsDragLeaveEvent(QDragLeaveEvent* e);
 			virtual void contentsDropEvent(QDropEvent* e);
@@ -85,7 +85,7 @@ namespace BALL
 			// output a string
 			void logString(const String& text);
 
-			public slots:
+			public Q_SLOTS:
 
 			virtual void showGuestContextMenu(const QPoint&);
 			

--- a/include/BALL/VIEW/WIDGETS/molecularControl.h
+++ b/include/BALL/VIEW/WIDGETS/molecularControl.h
@@ -199,7 +199,7 @@ class BALL_VIEW_EXPORT MolecularControl
 	 */
 	QMenu& getContextMenu();
 
-	public slots:
+	public Q_SLOTS:
 		
 	//@}
 	/** @name Public slots
@@ -326,7 +326,7 @@ class BALL_VIEW_EXPORT MolecularControl
 	/** @name Protected members 
 	*/ 
 	//@{
-	protected slots:
+	protected Q_SLOTS:
 
 	/*_ Controlling method for context menus.
 			Clear the previously created context menu.

--- a/include/BALL/VIEW/WIDGETS/molecularStructure.h
+++ b/include/BALL/VIEW/WIDGETS/molecularStructure.h
@@ -229,7 +229,7 @@ namespace BALL
 			const AssignBondOrderResultsDialog& getBondOrderResultsDialog() const { return bond_order_results_dialog_;}
 
 					
-			public slots:
+			public Q_SLOTS:
 
 			/** Centers the camera of Scene to the geometric center of the molecular objects
 					in the selection list.

--- a/include/BALL/VIEW/WIDGETS/propertyEditor.h
+++ b/include/BALL/VIEW/WIDGETS/propertyEditor.h
@@ -80,7 +80,7 @@ namespace BALL
 				 */
 				virtual PropEditorWidget* clone(const std::string& name, QWidget* parent) = 0;
 
-			signals:
+			Q_SIGNALS:
 				/**
 				 * This signal is triggered when the user requested to delete this property
 				 */
@@ -246,7 +246,7 @@ namespace BALL
 				PDBInfoEditorWidget(const PDBInfo& info, QWidget* parent);
 				virtual PDBInfoEditorWidget* clone(const std::string& name, QWidget* parent);
 
-			protected slots:
+			protected Q_SLOTS:
 				void startEditorDialog();
 
 			protected:
@@ -322,7 +322,7 @@ namespace BALL
 				 */
 				bool hasChanges() const;
 
-			public slots:
+			public Q_SLOTS:
 				/**
 				 * Apply all available changes
 				 */
@@ -333,7 +333,7 @@ namespace BALL
 				 */
 				void reset();
 
-			signals:
+			Q_SIGNALS:
 				/**
 				 * Emitted upon the first user made change to the editors
 				 */
@@ -348,7 +348,7 @@ namespace BALL
 				QString chooseName_(const QString& initial);
 				void deleteProperty_(PropEditorWidget* editor);
 
-			protected slots:
+			protected Q_SLOTS:
 				void scheduleDelete_();
 				void scheduleDuplicate_();
 				void valueChanged_();

--- a/include/BALL/VIEW/WIDGETS/pyWidget.h
+++ b/include/BALL/VIEW/WIDGETS/pyWidget.h
@@ -291,7 +291,7 @@ class BALL_VIEW_EXPORT BALL_DEPRECATED PyWidget
 	///
 	bool isInDirectMode() const;
 
-	public slots:
+	public Q_SLOTS:
 
 	//
 	void showEditContextMenu(const QPoint& point);
@@ -337,7 +337,7 @@ class BALL_VIEW_EXPORT BALL_DEPRECATED PyWidget
 
 	bool getMembers(const String& classname, QStringList& sl, const String& prefix);
 
-	protected slots:
+	protected Q_SLOTS:
 
 	virtual bool returnPressed();
 

--- a/include/BALL/VIEW/WIDGETS/scene.h
+++ b/include/BALL/VIEW/WIDGETS/scene.h
@@ -525,7 +525,7 @@ namespace BALL
 				virtual void keyPressEvent(QKeyEvent* e);
 
 			/////////////////////////////////////////
-			public slots:
+			public Q_SLOTS:
 				/// Create an coordinate system at current position
 				void createCoordinateSystem();
 
@@ -642,7 +642,7 @@ namespace BALL
 				int getEditElementType();
 
 			////////////////////////////////////////
-			protected slots:
+			protected Q_SLOTS:
 
 				/** @name Protected slots
 				*/
@@ -676,7 +676,7 @@ namespace BALL
 				//@}
 
 			////////////////////////////////////////
-			signals:
+			Q_SIGNALS:
 
 				// signal for communication with EditOperationDialog
 				void newEditOperation(EditOperation &eo);

--- a/include/BALL/VIEW/WIDGETS/shortcutTableView.h
+++ b/include/BALL/VIEW/WIDGETS/shortcutTableView.h
@@ -29,13 +29,11 @@ namespace BALL
 
 				void setFilter(const QString& filter);
 
-			signals:
+			Q_SIGNALS:
 				void shortcutChanged();
 
-			protected slots:
+			protected Q_SLOTS:
 				void editSuccess_();
-
-			protected slots:
 				void onClick(const QModelIndex& index);
 
 			private:

--- a/include/BALL/VIEW/WIDGETS/testFramework.h
+++ b/include/BALL/VIEW/WIDGETS/testFramework.h
@@ -111,7 +111,7 @@ namespace BALL
 			///
 			virtual bool openFile(const String& filename);
 
-			public slots:
+			public Q_SLOTS:
 
 			///
 			void startTest();

--- a/include/BALL/VIEW/WIDGETS/textEditorWidget.h
+++ b/include/BALL/VIEW/WIDGETS/textEditorWidget.h
@@ -58,7 +58,7 @@ namespace BALL
 			 
 			 void resizeEvent(QResizeEvent *event);
 
-			private slots:
+			private Q_SLOTS:
 				void updateLineNumbersWidth(int newBlockCount);
 				void highlightCurrentLine();
 				void updateLineNumbers(const QRect &, int);

--- a/source/APPLICATIONS/BALLVIEW/demoTutorialDialog.h
+++ b/source/APPLICATIONS/BALLVIEW/demoTutorialDialog.h
@@ -56,7 +56,7 @@ namespace BALL
 			///
 			//void setTutorialType(int type) { tutorial_type_ = type;}
 
-			public slots:
+			public Q_SLOTS:
 				
 			/// Show and raise the dialog
 			void show();

--- a/source/APPLICATIONS/BALLVIEW/main.C
+++ b/source/APPLICATIONS/BALLVIEW/main.C
@@ -103,7 +103,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, PSTR cmd_line, int)
 			QStringList dpaths = QString(p.getDataPath().c_str()).split("\n");
 
 			QTranslator* translator = new QTranslator(&application);
-			foreach(QString s, dpaths)
+			Q_FOREACH(QString s, dpaths)
 			{
 				translator->load(loc, s + "BALLView/translations");
 				if (!translator->isEmpty())

--- a/source/APPLICATIONS/BALLVIEW/mainframe.h
+++ b/source/APPLICATIONS/BALLVIEW/mainframe.h
@@ -35,7 +35,7 @@ namespace BALL
 		///
 		virtual ~Mainframe();
 
-		public slots:
+		public Q_SLOTS:
 
 		///
 		void show();

--- a/source/EXTENSIONS/BALLAXY/include/BALLaxyInterface.h
+++ b/source/EXTENSIONS/BALLAXY/include/BALLaxyInterface.h
@@ -25,7 +25,7 @@ namespace BALL
 				void setBALLaxyBaseUrl(const String& ballaxy_base);
 				bool uploadToBallaxy(AtomContainer* ac, const String& format);
 
-			public slots:
+			public Q_SLOTS:
 				void sendPDBToBallaxy();
 				void sendMOL2ToBallaxy();
 				void verifyDownloadRequest(QWebEngineDownloadItem* request);

--- a/source/EXTENSIONS/JUPYTER/include/jupyterPreferences.h
+++ b/source/EXTENSIONS/JUPYTER/include/jupyterPreferences.h
@@ -51,7 +51,7 @@ namespace BALL
 
 				void selectConnectionMode(ConnectionMode mode);
 
-			public slots:
+			public Q_SLOTS:
 				void selectConnectionMode(int index);
 				void selectExePath();
 				void selectNbdir();

--- a/source/EXTENSIONS/JUPYTER/include/jupyterServer.h
+++ b/source/EXTENSIONS/JUPYTER/include/jupyterServer.h
@@ -34,7 +34,7 @@ namespace BALL
 				QByteArray readStandardError();
 				QProcess::ProcessState state() const;
 
-			signals:
+			Q_SIGNALS:
 				void readyReadStandardOutput();
 				void readyReadStandardError();
 				void stateChanged(QProcess::ProcessState);

--- a/source/EXTENSIONS/JUPYTER/include/jupyterServerTab.h
+++ b/source/EXTENSIONS/JUPYTER/include/jupyterServerTab.h
@@ -24,7 +24,7 @@ namespace BALL
 				JupyterServer* getServer();
 				void setServer(JupyterServer* server);
 
-			public slots:
+			public Q_SLOTS:
 				void readStandardOutput();
 				void readStandardError();
 				void updateState(QProcess::ProcessState state);
@@ -32,7 +32,7 @@ namespace BALL
 				void processError(QProcess::ProcessError error);
 				void scrollToEnd();
 
-			signals:
+			Q_SIGNALS:
 				void appendMessage(const QString& /* message */);
 
 			protected:

--- a/source/EXTENSIONS/JUPYTER/include/jupyterTab.h
+++ b/source/EXTENSIONS/JUPYTER/include/jupyterTab.h
@@ -16,7 +16,7 @@ namespace BALL
 			public:
 				JupyterTab(QWidget* parent, JupyterWidget* base);
 
-			protected slots:
+			protected Q_SLOTS:
 				void prepareNotebook(bool ok);
 
 			protected:

--- a/source/EXTENSIONS/JUPYTER/include/jupyterWidget.h
+++ b/source/EXTENSIONS/JUPYTER/include/jupyterWidget.h
@@ -30,7 +30,7 @@ namespace BALL
 
 				virtual QWebEngineView* createWindow(QWebEnginePage::WebWindowType /*type*/);
 
-			public slots:
+			public Q_SLOTS:
 				void closeTab(int index);
 				void renameTab(const QString& title);
 

--- a/source/EXTENSIONS/PRESENTABALL/include/PresentaBALLSettings.h
+++ b/source/EXTENSIONS/PRESENTABALL/include/PresentaBALLSettings.h
@@ -42,7 +42,7 @@ namespace BALL
 				void setIndexHTMLLocation(const QString& path);
 				QString getIndexHTMLLocation();
 
-			public slots:
+			public Q_SLOTS:
 				virtual void selectIndexHTMLLocation();
 		};
 

--- a/source/EXTENSIONS/PRESENTABALL/include/PresentaBALLView.h
+++ b/source/EXTENSIONS/PRESENTABALL/include/PresentaBALLView.h
@@ -18,7 +18,7 @@ namespace BALL
 			public:
 				PresentaBALLSignal(QObject* parent = nullptr): QObject(parent) { }
 
-			signals:
+			Q_SIGNALS:
 				void actionSignal(int i);
 				void messageSignal(int i, int j);
 		};

--- a/source/EXTENSIONS/PRESENTABALL/source/PresentaBALLView.C
+++ b/source/EXTENSIONS/PRESENTABALL/source/PresentaBALLView.C
@@ -68,7 +68,7 @@ namespace BALL
 			if (cmsg)
 			{
 				// fire a Qt signal that can be handled by the website
-				emit signal_->messageSignal(0, (int) cmsg->getType()); // CompositeMessage = 0
+				Q_EMIT signal_->messageSignal(0, (int) cmsg->getType()); // CompositeMessage = 0
 
 #ifdef BALL_VIEW_DEBUG
 				Log.info() << "CompositeMessage fired to JS" << std::endl;
@@ -79,7 +79,7 @@ namespace BALL
 			RepresentationMessage* rmsg = RTTI::castTo<RepresentationMessage>(*message);
 			if (rmsg)
 			{
-				emit signal_->messageSignal(1, (int) rmsg->getType()); // RepresentationMessage = 1
+				Q_EMIT signal_->messageSignal(1, (int) rmsg->getType()); // RepresentationMessage = 1
 
 				#ifdef BALL_VIEW_DEBUG
 				Log.info() << "RepresentationMessage fired to JS" << std::endl;
@@ -90,7 +90,7 @@ namespace BALL
 			SceneMessage* smsg = RTTI::castTo<SceneMessage>(*message);
 			if (smsg)
 			{
-				emit signal_->messageSignal(2, (int) smsg->getType()); //SceneMessage = 2
+				Q_EMIT signal_->messageSignal(2, (int) smsg->getType()); //SceneMessage = 2
 
 #ifdef BALL_VIEW_DEBUG
 				Log.info() << "SceneMessage fired to JS" << std::endl;
@@ -101,7 +101,7 @@ namespace BALL
 			DatasetMessage* dmsg = RTTI::castTo<DatasetMessage>(*message);
 			if (dmsg)
 			{
-				emit signal_->messageSignal(3, (int) dmsg->getType()); //DataMessage = 3
+				Q_EMIT signal_->messageSignal(3, (int) dmsg->getType()); //DataMessage = 3
 
 #ifdef BALL_VIEW_DEBUG
 				Log.info() << "DataMessage fired to JS" << std::endl;

--- a/source/PLUGIN/pluginManager.C
+++ b/source/PLUGIN/pluginManager.C
@@ -65,7 +65,7 @@ namespace BALL
 			}
 
 			// collect the loaded plugins in this dir
-			foreach(QString it, plugin_dir.entryList())
+			Q_FOREACH(QString it, plugin_dir.entryList())
 			{
 				BALLPlugin* new_plugin = loadPlugin(plugin_dir.absoluteFilePath(it));
 				if (new_plugin)

--- a/source/PYTHON/EXTENSIONS/VIEW/dataset.sip
+++ b/source/PYTHON/EXTENSIONS/VIEW/dataset.sip
@@ -41,7 +41,7 @@ class DatasetController
 	String getType();
 	virtual void checkMenu(MainControl&);
 
-	public slots:
+	public Q_SLOTS:
 	virtual bool write();
 	virtual bool open();
 	virtual bool deleteDatasets();

--- a/source/PYTHON/EXTENSIONS/VIEW/lightSettings.sip
+++ b/source/PYTHON/EXTENSIONS/VIEW/lightSettings.sip
@@ -16,7 +16,7 @@ class LightSettings
 	virtual void restoreDefaultValues(bool /*all*/ = false);
 	void restoreValues(bool all);
 
-	public slots:
+	public Q_SLOTS:
 	virtual void addLightPressed();
 	virtual void colorPressed();
 	virtual void defaultsPressed();

--- a/source/PYTHON/EXTENSIONS/VIEW/scene.sip
+++ b/source/PYTHON/EXTENSIONS/VIEW/scene.sip
@@ -56,7 +56,7 @@ class Scene
 	void setFPSEnabled(bool);
 	void showText(const String&, Size /*font_size*/ = 20);
 
-	public slots:
+	public Q_SLOTS:
 
 	void createCoordinateSystem() throw();
 	void createCoordinateSystemAtOrigin() throw();

--- a/source/PYTHON/EXTENSIONS/VIEW/standardDatasets.sip
+++ b/source/PYTHON/EXTENSIONS/VIEW/standardDatasets.sip
@@ -19,7 +19,7 @@ class RegularData3DController
 	RegularData3D* createHistogramGrid(const RegularData3D&);
 	RegularData3D* getData(Dataset*);
 
-	public slots:
+	public Q_SLOTS:
 	bool createVectorGrid();
 	void computeIsoContourSurface();
 	void resizeGrid();
@@ -44,7 +44,7 @@ class TrajectoryController
 	virtual Dataset* open(String /*filetype*/, String /*filename*/);
 	SnapShotManager* getData(Dataset*);
 
-	public slots:
+	public Q_SLOTS:
 	bool visualizeTrajectory();
 	bool bufferTrajectory();
 };

--- a/source/SYSTEM/simpleDownloader.C
+++ b/source/SYSTEM/simpleDownloader.C
@@ -120,7 +120,7 @@ namespace BALL
 			Log.error() << "SSL error(s) while downloading. Errors are:\n";
 
 			QSslError ssl_error;
-			foreach(ssl_error, errors) {
+			Q_FOREACH(ssl_error, errors) {
 				Log.error() << ssl_error.errorString().toStdString() << "\n";
 			}
 

--- a/source/VIEW/DIALOGS/mainControlPreferences.C
+++ b/source/VIEW/DIALOGS/mainControlPreferences.C
@@ -34,10 +34,10 @@ MainControlPreferences::MainControlPreferences(QWidget* parent, const char* name
 	QStringList dpaths = QString(p.getDataPath().c_str()).split("\n");
 
 	languageComboBox_->addItem("English (default)", QVariant("en_US"));
-	foreach(QString str, dpaths) {
+	Q_FOREACH(QString str, dpaths) {
 		QDir dir(str + "BALLView/translations");
 		QStringList tList = dir.entryList(QStringList("BALLView-*.qm"));
-		foreach(QString entry, tList) {
+		Q_FOREACH(QString entry, tList) {
 			entry.replace("BALLView-", "");
 			entry.replace(".qm", "");
 			languageComboBox_->addItem(QLocale::languageToString(QLocale(entry).language()), QVariant(entry));

--- a/source/VIEW/DIALOGS/preferences.C
+++ b/source/VIEW/DIALOGS/preferences.C
@@ -325,7 +325,7 @@ namespace BALL
 
 			switch(buttonBox->buttonRole(button)) {
 				case QDialogButtonBox::ApplyRole:
-					emit applied();
+					Q_EMIT applied();
 					break;
 				case QDialogButtonBox::ResetRole:
 					setDefaultValues();

--- a/source/VIEW/KERNEL/MODES/editMode.C
+++ b/source/VIEW/KERNEL/MODES/editMode.C
@@ -373,7 +373,7 @@ namespace BALL
 						+ String(atom_position.z) + ")", EditOperation::ADDED__ATOM);
 				undo_.push_back(eo);
 				// tell about the new undo operation
-				emit newEditOperation(eo);
+				Q_EMIT newEditOperation(eo);
 */
 				return;
 			}
@@ -441,7 +441,7 @@ namespace BALL
 				undo_.push_back(eo);
 
 				// tell about the new undo operation
-				emit newEditOperation(eo);
+				Q_EMIT newEditOperation(eo);
 */
 				scene_->merge(scene_->getCurrentAtom(), atom);
 
@@ -481,7 +481,7 @@ namespace BALL
 				undo_.push_back(eo);
 
 				// tell about the new undo operation
-				emit newEditOperation(eo);
+				Q_EMIT newEditOperation(eo);
 */
 				// set the bond
 				new Bond("Bond", *scene_->getCurrentAtom(), *a, Bond::ORDER__SINGLE);
@@ -492,7 +492,7 @@ namespace BALL
 				String bond_string = getBondOrderString_(bond_order_);
 				EditOperation eo2(0, c, (String)qApp->tr("Edit Mode", "Added bond of type ") + bond_string, EditOperation::ADDED__BOND);
 				undo_.push_back(eo2);
-				emit newEditOperation(eo2);
+				Q_EMIT newEditOperation(eo2);
 				*/
 
 				scene_->getMainControl()->update(*a->getParent(), true);
@@ -1001,7 +1001,7 @@ namespace BALL
 				// 		undo_.push_back(eo);
 				//
 				// 		// tell about the new undo operation
-				// 		emit newEditOperation(eo);
+				// 		Q_EMIT newEditOperation(eo);
 
 				// if the bond is between two molecules, merge them
 				scene_->merge(first_atom, second_atom);

--- a/source/VIEW/KERNEL/MODES/interactionMode.C
+++ b/source/VIEW/KERNEL/MODES/interactionMode.C
@@ -27,7 +27,7 @@ namespace BALL
 
 		void InteractionMode::modeChangeSlot_()
 		{
-			emit requestModeChange(this);
+			Q_EMIT requestModeChange(this);
 		}
 
 		void InteractionMode::addToolBarEntries(QToolBar* tb)

--- a/source/VIEW/KERNEL/MODES/moveMode.C
+++ b/source/VIEW/KERNEL/MODES/moveMode.C
@@ -224,7 +224,7 @@ namespace BALL
 			scene_->getCurrentAtom()->setSelected(true);
 			scene_->notify(new CompositeMessage(*scene_->getCurrentAtom(), CompositeMessage::SELECTED_COMPOSITE));
 
-			emit InteractionMode::requestModeChange(this);
+			Q_EMIT InteractionMode::requestModeChange(this);
 		}
 
 	}

--- a/source/VIEW/KERNEL/serverWidget.C
+++ b/source/VIEW/KERNEL/serverWidget.C
@@ -205,7 +205,7 @@ namespace BALL
 
 		void ServerWidget::changeLock(bool lock)
 		{
-			emit lockRequested(lock);
+			Q_EMIT lockRequested(lock);
 		}
 
 		void ServerWidget::handleLocking(bool lock)

--- a/source/VIEW/KERNEL/shortcutRegistry.C
+++ b/source/VIEW/KERNEL/shortcutRegistry.C
@@ -66,7 +66,7 @@ namespace BALL
 				shortcut_keys_.insert(key_seq);
 			}
 
-			emit shortcutChanged();
+			Q_EMIT shortcutChanged();
 		}
 
 		void ShortcutRegistry::clear()
@@ -74,7 +74,7 @@ namespace BALL
 			shortcuts_.clear();
 			shortcut_keys_.clear();
 
-			emit shortcutChanged();
+			Q_EMIT shortcutChanged();
 		}
 
 		void ShortcutRegistry::clearKeySequences()
@@ -86,7 +86,7 @@ namespace BALL
 			}
 			shortcut_keys_.clear();
 
-			emit shortcutChanged();
+			Q_EMIT shortcutChanged();
 		}
 
 		bool ShortcutRegistry::readShortcutsFromFile(const String& filename)
@@ -144,7 +144,7 @@ namespace BALL
 
 			infile.close();
 
-			emit shortcutChanged();
+			Q_EMIT shortcutChanged();
 
 			return true;
 		}

--- a/source/VIEW/WIDGETS/HTMLPage.C
+++ b/source/VIEW/WIDGETS/HTMLPage.C
@@ -17,7 +17,7 @@ namespace BALL
 		void HTMLInterfaceAction::execute(const QList<QPair<QString, QString> >& parameters)
 		{
 			executeImpl_(parameters);
-			emit finishedExecution();
+			Q_EMIT finishedExecution();
 		}
 
 		HTMLPage::HTMLPage(QObject* parent, bool ignore_ssl_errors)

--- a/source/VIEW/WIDGETS/colorButton.C
+++ b/source/VIEW/WIDGETS/colorButton.C
@@ -77,7 +77,7 @@ namespace BALL
 
 			if(tmp.isValid()) {
 				color_ = tmp;
-				emit colorChanged(color_);
+				Q_EMIT colorChanged(color_);
 			}
 		}
 

--- a/source/VIEW/WIDGETS/hotkeyTable.C
+++ b/source/VIEW/WIDGETS/hotkeyTable.C
@@ -183,7 +183,7 @@ namespace BALL
 			item(p, 1)->setText("F2");
 			item(p, 2)->setText("");
 			item(p, 3)->setText("");
-			emit(cellActivated(p, 2));
+			Q_EMIT cellActivated(p, 2);
 		}
 
 		void HotkeyTable::removeSelection()

--- a/source/VIEW/WIDGETS/propertyEditor.C
+++ b/source/VIEW/WIDGETS/propertyEditor.C
@@ -50,7 +50,7 @@ namespace BALL
 				is_editable_ = mode;
 
 				QObject* child;
-				foreach(child, ui_.editors->children())
+				Q_FOREACH(child, ui_.editors->children())
 				{
 					PropEditorWidget* editor = qobject_cast<PropEditorWidget*>(child);
 					if(editor)
@@ -110,7 +110,7 @@ namespace BALL
 
 			//First we need to remove all
 			QObject* child;
-			foreach(child, ui_.editors->children())
+			Q_FOREACH(child, ui_.editors->children())
 			{
 				PropEditorWidget* editor = qobject_cast<PropEditorWidget*>(child);
 				if(editor)
@@ -139,14 +139,14 @@ namespace BALL
 
 			//Delete all properties which have been scheduled for deletion
 			PropEditorWidget* prop;
-			foreach(prop, deleted_properties_)
+			Q_FOREACH(prop, deleted_properties_)
 			{
 				deleteProperty_(prop);
 			}
 
 			//Apply all other properties
 			QObject* child;
-			foreach(child, ui_.editors->children())
+			Q_FOREACH(child, ui_.editors->children())
 			{
 				PropEditorWidget* editor = qobject_cast<PropEditorWidget*>(child);
 				if(editor)
@@ -175,14 +175,14 @@ namespace BALL
 
 			//The user discarded the newly added properties
 			PropEditorWidget* prop;
-			foreach(prop, new_properties_)
+			Q_FOREACH(prop, new_properties_)
 			{
 				deleteProperty_(prop);
 			}
 
 			//And wants us to reread the old property values
 			QObject* child;
-			foreach(child, ui_.editors->children())
+			Q_FOREACH(child, ui_.editors->children())
 			{
 				PropEditorWidget* editor = qobject_cast<PropEditorWidget*>(child);
 				if(editor)
@@ -387,7 +387,7 @@ namespace BALL
 				//We need to check the inserted name against all properties and properties scheduled for creation
 				bool not_used = true;
 				PropEditorWidget* e;
-				foreach(e, new_properties_)
+				Q_FOREACH(e, new_properties_)
 				{
 					if(e->getName() == new_name)
 					{
@@ -410,7 +410,7 @@ namespace BALL
 			//We only want to emit this signal once
 			if(!has_changes_)
 			{
-				emit valueChanged();
+				Q_EMIT valueChanged();
 
 				has_changes_ = true;
 			}
@@ -707,12 +707,12 @@ namespace BALL
 
 				int n = 0;
 				skipped.clear();
-				foreach(QString line, lines) {
+				Q_FOREACH(QString line, lines) {
 					skipped.push_back(String(line));
 					n++;
 				}
 				// don't forget to emit this -- else changes won't be written back!
-				emit valueChanged();
+				Q_EMIT valueChanged();
 			}
 		}
 

--- a/source/VIEW/WIDGETS/shortcutTableView.C
+++ b/source/VIEW/WIDGETS/shortcutTableView.C
@@ -109,7 +109,7 @@ namespace BALL
 			{
 				// TODO: getDescription(QKeySequence) in shortcutRegistry to provide more helpful message.
 				Scene::getInstance(0)->setStatusbarText("Shortcut " + ascii(new_seq) + " successfully set.");
-				emit dataChanged(index, index);
+				Q_EMIT dataChanged(index, index);
 				return true;
 			}
 
@@ -179,7 +179,7 @@ namespace BALL
 
 			if(model()->setData(model()->index(edited_row_, 1, QModelIndex()),
 			                 QVariant::fromValue(editor_->getKeySequence()))) {
-				emit shortcutChanged();
+				Q_EMIT shortcutChanged();
 			}
 		}
 


### PR DESCRIPTION
BALL currently uses the Qt-specific `emit`, `signals`, `slots`, and `foreach` "keywords", which will cause some issues when migrating to Python 3. The new `Python.h` uses a member variable `slots` for one of its structs, leaving broken code after MOC and preprocessor runs due to the name clash [1]. Thus, I suggest to replace all occurrences of the keywords by the corresponding prefixed macros
 * `emit` -> `Q_EMIT`
 * `signals` -> `Q_SIGNALS`
 * `slots` -> `Q_SLOTS`
 * `foreach` -> `Q_FOREACH`

and disable the former.
Any objections?

[1]
```
In file included from /usr/include/python3.6m/pytime.h:6:0,
                 from /usr/include/python3.6m/Python.h:65,
                 from /home/thomas/git/apps/ball/include/BALL/PYTHON/pyKernel.h:6,
                 from /home/thomas/git/apps/ball/include/BALL/PYTHON/pyInterpreter.h:11,
                 from /home/thomas/git/apps/ball/source/PYTHON/pyServer.C:4:
/usr/include/python3.6m/object.h:448:23: error: expected unqualified-id before ‘;’ token
     PyType_Slot *slots; /* terminated by slot==0. */
```